### PR TITLE
Enable find widget in goal view

### DIFF
--- a/client/src/panels/GoalPanel.ts
+++ b/client/src/panels/GoalPanel.ts
@@ -85,6 +85,8 @@ export default class GoalPanel {
           localResourceRoots: [Uri.joinPath(extensionUri, "out"), Uri.joinPath(extensionUri, "goal-view-ui/build")],
 
           retainContextWhenHidden: true,
+
+          enableFindWidget: true,
         }
       );
 


### PR DESCRIPTION
An user requested the possibility to use the find widget in the goal view.
The change should not have any impact if users does not use ctrl+f