### PR TITLE
config: Add prettier formatter

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,24 +1,19 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "@typescript-eslint/naming-convention": "warn",
-        "@typescript-eslint/semi": "warn",
-        "curly": "warn",
-        "eqeqeq": "warn",
-        "no-throw-literal": "warn",
-        "semi": "off"
-    },
-    "ignorePatterns": [
-        "out",
-        "dist",
-        "**/*.d.ts"
-    ]
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/semi": "warn",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn",
+    "semi": "off"
+  },
+  "ignorePatterns": ["out", "dist", "**/*.d.ts"],
+  "extends": ["prettier"]
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -12,7 +12,18 @@
     "curly": "warn",
     "eqeqeq": "warn",
     "no-throw-literal": "warn",
-    "semi": "off"
+    "semi": "off",
+    // note you must disable the base rule
+    // as it can report incorrect errors
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn", // or "error"
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   },
   "ignorePatterns": ["out", "dist", "**/*.d.ts"],
   "extends": ["prettier"]

--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,0 +1,15 @@
+# Ignore artifacts:
+build
+coverage
+out/
+dist/
+
+# VSCode
+.vscode
+.vscode-test/
+
+
+# Webviews
+## Ignoring these since they have their own settings
+goal-view-ui
+search-ui

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -12,5 +12,7 @@
     "typescript.tsc.autoDetect": "off",
     "ocaml.sandbox": {
         "kind": "global"
-    }
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
 }

--- a/client/package.json
+++ b/client/package.json
@@ -109,12 +109,12 @@
         "title": "Memory management",
         "type": "object",
         "properties": {
-            "vscoq.memory.limit": {
-                "scope": "workspace",
-                "type": "number",
-                "default": 4,
-                "description": "Sets the memory limit over which we discard the execution state of documents which have been saved (in Gb). "
-            }
+          "vscoq.memory.limit": {
+            "scope": "workspace",
+            "type": "number",
+            "default": 4,
+            "description": "Sets the memory limit over which we discard the execution state of documents which have been saved (in Gb). "
+          }
         }
       },
       {
@@ -913,9 +913,12 @@
     "@vscode/test-electron": "^2.2.0",
     "@vscode/vsce": "^2.19.0",
     "eslint": "^8.28.0",
+    "eslint-config-prettier": "^9.1.0",
     "expect": "^29.4.3",
     "glob": "^8.0.3",
     "mocha": "^10.1.0",
+    "prettier": "3.3.3",
+    "prettier-plugin-organize-imports": "^4.0.0",
     "tmp-promise": "^3.0.3",
     "ts-loader": "^9.4.1",
     "typescript": "^4.9.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1087,6 +1087,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+eslint-config-prettier@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2177,6 +2182,16 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-plugin-organize-imports@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.0.0.tgz#a69acf024ea3c8eb650c81f664693826ca853534"
+  integrity sha512-vnKSdgv9aOlqKeEFGhf9SCBsTyzDSyScy1k7E0R1Uo4L0cTcOV7c1XQaT7jfXIOc/p08WLBfN2QUQA9zDSZMxA==
+
+prettier@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 pretty-format@^29.7.0:
   version "29.7.0"

--- a/client/yarn.nix
+++ b/client/yarn.nix
@@ -1258,6 +1258,14 @@
       };
     }
     {
+      name = "eslint_config_prettier___eslint_config_prettier_9.1.0.tgz";
+      path = fetchurl {
+        name = "eslint_config_prettier___eslint_config_prettier_9.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz";
+        sha512 = "NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==";
+      };
+    }
+    {
       name = "eslint_scope___eslint_scope_5.1.1.tgz";
       path = fetchurl {
         name = "eslint_scope___eslint_scope_5.1.1.tgz";
@@ -2519,6 +2527,22 @@
         name = "prelude_ls___prelude_ls_1.2.1.tgz";
         url  = "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz";
         sha512 = "vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==";
+      };
+    }
+    {
+      name = "prettier_plugin_organize_imports___prettier_plugin_organize_imports_4.0.0.tgz";
+      path = fetchurl {
+        name = "prettier_plugin_organize_imports___prettier_plugin_organize_imports_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.0.0.tgz";
+        sha512 = "vnKSdgv9aOlqKeEFGhf9SCBsTyzDSyScy1k7E0R1Uo4L0cTcOV7c1XQaT7jfXIOc/p08WLBfN2QUQA9zDSZMxA==";
+      };
+    }
+    {
+      name = "prettier___prettier_3.3.3.tgz";
+      path = fetchurl {
+        name = "prettier___prettier_3.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz";
+        sha512 = "i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==";
       };
     }
     {


### PR DESCRIPTION
Adding a base setup to have a formatter for the main extension files.
It is not formatting the goal view nor search ui because they have separate config files, which I think can be handled differently (vite setup).
Fixed some typos.