### PR TITLE
#1093: Renaming: vsrocq -> prover

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -52,7 +52,7 @@ export function activate(context: ExtensionContext) {
     const getDocumentProofs = (uri: Uri) => {
         const textDocument = TextDocumentIdentifier.create(uri.toString());
         const params: DocumentProofsRequest = {textDocument};
-        const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vsrocq/documentProofs");
+        const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("prover/documentProofs");
         Client.writeToVsrocqChannel("Getting proofs for: " + uri.toString());
         return client.sendRequest(req, params);
     };
@@ -184,7 +184,7 @@ export function activate(context: ExtensionContext) {
             const uri = editor.document.uri;
             const textDocument = TextDocumentIdentifier.create(uri.toString());
             const params: ResetRocqRequest = {textDocument};
-            const req = new RequestType<ResetRocqRequest, ResetRocqResponse, void>("vsrocq/resetRocq");
+            const req = new RequestType<ResetRocqRequest, ResetRocqResponse, void>("prover/resetRocq");
             Client.writeToVsrocqChannel(uri.toString());
             client.sendRequest(req, params).then(
                 (res) => {
@@ -246,7 +246,7 @@ export function activate(context: ExtensionContext) {
             GoalPanel.displayProofView(context.extensionUri, editor);
         });
             
-        client.onNotification("vsrocq/updateHighlights", (notification) => {
+        client.onNotification("prover/updateHighlights", (notification) => {
         
             client.saveHighlights(
                 notification.uri,
@@ -258,7 +258,7 @@ export function activate(context: ExtensionContext) {
             client.updateHightlights();
         });
 
-        client.onNotification("vsrocq/moveCursor", (notification: MoveCursorNotification) => {
+        client.onNotification("prover/moveCursor", (notification: MoveCursorNotification) => {
             const {uri, range} = notification;
             const editors = window.visibleTextEditors.filter(editor => {
                 return editor.document.uri.toString() === uri.toString();
@@ -272,22 +272,22 @@ export function activate(context: ExtensionContext) {
             }
         });
 
-        client.onNotification("vsrocq/searchResult", (searchResult: SearchRocqResult) => {
+        client.onNotification("prover/searchResult", (searchResult: SearchRocqResult) => {
             searchProvider.renderSearchResult(searchResult);
         });
 
-        client.onNotification("vsrocq/proofView", (proofView: ProofViewNotification) => {
+        client.onNotification("prover/proofView", (proofView: ProofViewNotification) => {
             const editor = window.activeTextEditor ? window.activeTextEditor : window.visibleTextEditors[0];
             const autoDisplay = workspace.getConfiguration('vsrocq.goals').auto;
             GoalPanel.proofViewNotification(context.extensionUri, editor, proofView, autoDisplay);
         });
 
-        client.onNotification("vsrocq/blockOnError", (notification: ErrorAlertNotification) => {
+        client.onNotification("prover/blockOnError", (notification: ErrorAlertNotification) => {
             const {uri, range} = notification;
             client.createErrorAnimation(uri.toString(), [range]);
         });
 
-        client.onNotification("vsrocq/debugMessage", (rocqMessage: RocqLogMessage) => {
+        client.onNotification("prover/debugMessage", (rocqMessage: RocqLogMessage) => {
             const {message} = rocqMessage;
             const messageString = `${message}`;
             Client.writeRocqMessageLog(messageString);

--- a/client/src/manualChecking.ts
+++ b/client/src/manualChecking.ts
@@ -17,21 +17,21 @@ import { makeVersionedDocumentId } from './utilities/utils';
 export const sendInterpretToPoint = (editor: TextEditor, client: Client) => {
     const textDocument = makeVersionedDocumentId(editor);
     const position = editor.selection.active;
-    client.sendNotification("vsrocq/interpretToPoint", {textDocument: textDocument, position: position });
+    client.sendNotification("prover/interpretToPoint", {textDocument: textDocument, position: position });
 };
 
 export const sendInterpretToEnd = (editor: TextEditor,  client: Client) => {
     const textDocument = makeVersionedDocumentId(editor);
-    client.sendNotification("vsrocq/interpretToEnd", {textDocument: textDocument});
+    client.sendNotification("prover/interpretToEnd", {textDocument: textDocument});
 };
 
 export const sendStepForward = (editor: TextEditor,  client: Client) => {
     const textDocument = makeVersionedDocumentId(editor);
-    client.sendNotification("vsrocq/stepForward", {textDocument: textDocument});
+    client.sendNotification("prover/stepForward", {textDocument: textDocument});
 };
 
 export const sendStepBackward = (editor: TextEditor,  client: Client) => {
     const textDocument = makeVersionedDocumentId(editor);
-    client.sendNotification("vsrocq/stepBackward", {textDocument: textDocument});
+    client.sendNotification("prover/stepBackward", {textDocument: textDocument});
 };
 

--- a/client/src/panels/DocumentStateViewProvider.ts
+++ b/client/src/panels/DocumentStateViewProvider.ts
@@ -51,7 +51,7 @@ export class DocumentStateViewProvider implements TextDocumentContentProvider {
         }
 
         const params: DocumentStateRequest = {textDocument: this.textDocument}; 
-        const req = new RequestType<DocumentStateRequest, DocumentStateResponse, void>("vsrocq/documentState");
+        const req = new RequestType<DocumentStateRequest, DocumentStateResponse, void>("prover/documentState");
         Client.writeToVsrocqChannel("[DocumentStateViewProvider] Getting document state for uri: " + this.textDocument.uri.toString());
         return this._client.sendRequest(req, params).then(
             (result: DocumentStateResponse) => {

--- a/client/src/panels/SearchViewProvider.ts
+++ b/client/src/panels/SearchViewProvider.ts
@@ -163,7 +163,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
                     if(type === "search") {  
                         const params: SearchRocqRequest = {id, textDocument, pattern, position};
-                        const req = new RequestType<SearchRocqRequest, SearchRocqHandshake, void>("vsrocq/search");
+                        const req = new RequestType<SearchRocqRequest, SearchRocqHandshake, void>("prover/search");
                         client.sendRequest(req, params).then(
                             (handshake: SearchRocqHandshake) => {
                                 webview.postMessage({"command": "launchedSearch"});
@@ -177,7 +177,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
                     if(type === "about") {
                         const params: AboutRocqRequest = {textDocument, pattern, position};
-                        const req = new RequestType<AboutRocqRequest, AboutRocqResponse, void>("vsrocq/about");
+                        const req = new RequestType<AboutRocqRequest, AboutRocqResponse, void>("prover/about");
                             
                         client.sendRequest(req, params).then(
                             (result: AboutRocqResponse) => {
@@ -193,7 +193,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
                     if(type === "check") {
                         const params: CheckRocqRequest = {textDocument, pattern, position};
-                        const req = new RequestType<CheckRocqRequest, CheckRocqResponse, void>("vsrocq/check");
+                        const req = new RequestType<CheckRocqRequest, CheckRocqResponse, void>("prover/check");
                             
                         client.sendRequest(req, params).then(
                             (result: CheckRocqResponse) => {
@@ -209,7 +209,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
                     if(type === "locate") {
                         const params: CheckRocqRequest = {textDocument, pattern, position};
-                        const req = new RequestType<LocateRocqRequest, LocateRocqResponse, void>("vsrocq/locate");
+                        const req = new RequestType<LocateRocqRequest, LocateRocqResponse, void>("prover/locate");
                             
                         client.sendRequest(req, params).then(
                             (result: LocateRocqResponse) => {
@@ -225,7 +225,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
                     if(type === "print") {
                         const params: CheckRocqRequest = {textDocument, pattern, position};
-                        const req = new RequestType<PrintRocqRequest, PrintRocqResponse, void>("vsrocq/print");
+                        const req = new RequestType<PrintRocqRequest, PrintRocqResponse, void>("prover/print");
                             
                         client.sendRequest(req, params).then(
                             (result: PrintRocqResponse) => {

--- a/language-server/protocol/extProtocol.ml
+++ b/language-server/protocol/extProtocol.ml
@@ -64,16 +64,16 @@ module Notification = struct
     let of_jsonrpc (Jsonrpc.Notification.{ method_; params } as notif) =
       let open Lsp.Import.Result.O in
       match method_ with
-      | "vsrocq/interpretToPoint" ->
+      | "prover/interpretToPoint" ->
         let+ params = Lsp.Import.Json.message_params params InterpretToPointParams.t_of_yojson in
         InterpretToPoint params
-      | "vsrocq/stepBackward" ->
+      | "prover/stepBackward" ->
         let+ params = Lsp.Import.Json.message_params params StepBackwardParams.t_of_yojson in
         StepBackward params
-      | "vsrocq/stepForward" ->
+      | "prover/stepForward" ->
         let+ params = Lsp.Import.Json.message_params params StepForwardParams.t_of_yojson in
         StepForward params
-      | "vsrocq/interpretToEnd" ->
+      | "prover/interpretToEnd" ->
         let+ params = Lsp.Import.Json.message_params params InterpretToEndParams.t_of_yojson in
         InterpretToEnd params
       | _ ->
@@ -134,32 +134,32 @@ module Notification = struct
       | Std notification ->
         Lsp.Server_notification.to_jsonrpc notification
       | UpdateHighlights params ->
-        let method_ = "vsrocq/updateHighlights" in
+        let method_ = "prover/updateHighlights" in
         let params = yojson_of_overview params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }
       | ProofView params -> 
-        let method_ = "vsrocq/proofView" in
+        let method_ = "prover/proofView" in
         let params = ProofViewParams.yojson_of_t params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }
       | SearchResult params ->
-        let method_ = "vsrocq/searchResult" in
+        let method_ = "prover/searchResult" in
         let params = yojson_of_query_result params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }      
       | MoveCursor params ->
-        let method_ = "vsrocq/moveCursor" in 
+        let method_ = "prover/moveCursor" in 
         let params = MoveCursorParams.yojson_of_t params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }
       | BlockOnError params ->
-        let method_ = "vsrocq/blockOnError" in 
+        let method_ = "prover/blockOnError" in 
         let params = BlockOnErrorParams.yojson_of_t params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }
       | RocqLogMessage params ->
-        let method_ = "vsrocq/debugMessage" in
+        let method_ = "prover/debugMessage" in
         let params = RocqLogMessageParams.yojson_of_t params in
         let params = Some (Jsonrpc.Structured.t_of_yojson params) in
         Jsonrpc.Notification.{ method_; params }
@@ -280,28 +280,28 @@ module Request = struct
   let t_of_jsonrpc (Jsonrpc.Request.{ method_; params } as req) =
     let open Lsp.Import.Result.O in
     match method_ with
-    | "vsrocq/resetRocq" ->
+    | "prover/resetRocq" ->
       let+ params = Lsp.Import.Json.message_params params ResetParams.t_of_yojson in
       Pack (Reset params)
-    | "vsrocq/search" ->
+    | "prover/search" ->
       let+ params = Lsp.Import.Json.message_params params SearchParams.t_of_yojson in
       Pack (Search params)
-    | "vsrocq/about" ->
+    | "prover/about" ->
       let+ params = Lsp.Import.Json.message_params params AboutParams.t_of_yojson in
       Pack (About params)
-    | "vsrocq/check" ->
+    | "prover/check" ->
       let+ params = Lsp.Import.Json.message_params params CheckParams.t_of_yojson in
       Pack (Check params)
-    | "vsrocq/locate" ->
+    | "prover/locate" ->
       let+ params = Lsp.Import.Json.message_params params LocateParams.t_of_yojson in
       Pack (Locate params)
-    | "vsrocq/print" ->
+    | "prover/print" ->
       let+ params = Lsp.Import.Json.message_params params PrintParams.t_of_yojson in
       Pack (Print params)
-    | "vsrocq/documentState" ->
+    | "prover/documentState" ->
       let+ params = Lsp.Import.Json.message_params params DocumentStateParams.t_of_yojson in
       Pack (DocumentState params)
-    | "vsrocq/documentProofs" ->
+    | "prover/documentProofs" ->
       let+ params = Lsp.Import.Json.message_params params DocumentProofsParams.t_of_yojson in
       Pack (DocumentProofs params)
     | _ ->

--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -586,10 +586,10 @@ let dispatch_std_notification =
 
 let dispatch_notification =
   let open Notification.Client in function
-  | InterpretToPoint params -> log (fun () -> "Received notification: vsrocq/interpretToPoint"); rocqtopInterpretToPoint params 
-  | InterpretToEnd params -> log (fun () -> "Received notification: vsrocq/interpretToEnd"); rocqtopInterpretToEnd params
-  | StepBackward params -> log (fun () -> "Received notification: vsrocq/stepBackward"); rocqtopStepBackward params
-  | StepForward params -> log (fun () -> "Received notification: vsrocq/stepForward"); rocqtopStepForward params
+  | InterpretToPoint params -> log (fun () -> "Received notification: prover/interpretToPoint"); rocqtopInterpretToPoint params
+  | InterpretToEnd params -> log (fun () -> "Received notification: prover/interpretToEnd"); rocqtopInterpretToEnd params
+  | StepBackward params -> log (fun () -> "Received notification: prover/stepBackward"); rocqtopStepBackward params
+  | StepForward params -> log (fun () -> "Received notification: prover/stepForward"); rocqtopStepForward params
   | Std notif -> dispatch_std_notification notif
 
 let handle_lsp_event = function


### PR DESCRIPTION
Changing ``vsrocq`` to ``prover``.

VsRocq trace:
```
[Trace - 6:29:38 PM] Sending notification 'prover/stepForward'.
Params: {
    "textDocument": {
        "uri": "file:///home/***/Downloads/bank.v",
        "version": 1
    }
}
```

Closing issue #1093 

