### PR TITLE
fix: rocq version display

### DIFF
--- a/client/src/utilities/toolchain.ts
+++ b/client/src/utilities/toolchain.ts
@@ -146,7 +146,7 @@ export default class VsRocqToolchainManager implements Disposable {
                 if(error) {
                     reject(stderr);
                 } else {
-                    const versionRegexp = /\b\d\.\d+(\.\d|\+rc\d)\b/g;
+                    const versionRegexp = /\b\d\.\d+(\.\d|\+rc\d|\.dev)\b/g;
                     this._versionFullOutput = stdout;
                     const matchArray = stdout.match(versionRegexp);
                     if(matchArray) {

--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -51,7 +51,7 @@ let Dm.Types.Log log = Dm.Log.mk_log "lspManager"
 let conf_request_id = max_int
 
 let server_info = InitializeResult.create_serverInfo
-  ~name:"vscoq-language-server"
+  ~name:"vsrocq-language-server"
   ~version:"2.2.6"
   ()
 


### PR DESCRIPTION
Closes #1122.

@gares maybe we could have an exhaustive description of rocq version semantics ? This would avoid this kind of mess