### PR TITLE
feat: add an option to render goal view as formatted string + add range

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -168,6 +168,13 @@
             "default": "off",
             "markdownDescription": "Controls vsrocq's diff mode. If `on`, only added characters are displayed. If `removed` is selected, both added and removed characters are shown."
           },
+          "vsrocq.goals.ppmode": {
+            "type": "string",
+            "enum": ["Pp"],
+            "default": "Pp",
+            "description": "This read-only setting is to indicate to the server to send goals in pretty printed format instead of plain text.",
+            "readOnly": true
+          },
           "vsrocq.goals.messages.full": {
             "type": "boolean",
             "default": true,

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -120,7 +120,7 @@ val get_proof : state -> Settings.Goals.Diff.Mode.t -> sentence_id option -> Pro
 
 val get_completions : state -> Position.t -> completion_item list 
 
-val handle_event : event -> state -> block:bool -> Settings.Mode.t -> Settings.Goals.Diff.Mode.t -> handled_event
+val handle_event : event -> state -> block:bool -> Settings.Mode.t -> Settings.Goals.Diff.Mode.t -> Settings.Goals.PrettyPrint.t -> handled_event
 (** handles events and returns a new state if it was updated. On top of the next events, it also returns info
     on whether execution has halted due to an error and returns a boolean flag stating whether the view
     should be updated *)

--- a/language-server/protocol/extProtocol.ml
+++ b/language-server/protocol/extProtocol.ml
@@ -105,8 +105,11 @@ module Notification = struct
     module ProofViewParams = struct
 
       type t = {
+        range: Range.t;
         proof: ProofState.t option;
         messages: (DiagnosticSeverity.t * pp) list;
+        pp_proof: PpProofState.t option;
+        pp_messages: (DiagnosticSeverity.t *string) list;
       } [@@deriving yojson]
 
     end

--- a/language-server/protocol/ppProofState.ml
+++ b/language-server/protocol/ppProofState.ml
@@ -1,0 +1,121 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 VSRocq                                 *)
+(*                                                                        *)
+(*                   Copyright INRIA and contributors                     *)
+(*       (see version control and README file for authors & dates)        *)
+(*                                                                        *)
+(**************************************************************************)
+(*                                                                        *)
+(*   This file is distributed under the terms of the MIT License.         *)
+(*   See LICENSE file.                                                    *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Printing
+open Lsp.Types
+
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type hypothesis = {
+  ids: string list;
+  body: string option;
+  _type: string;
+} [@@deriving yojson]
+
+type goal = {
+  id: int;
+  hypotheses: hypothesis list;
+  goal: string;
+} [@@deriving yojson]
+
+type t = {
+  goals: goal list;
+  shelvedGoals: goal list;
+  givenUpGoals: goal list;
+  unfocusedGoals: goal list;
+} [@@deriving yojson]
+
+open Printer
+module CompactedDecl = Context.Compacted.Declaration
+
+let mk_pp_hyp env sigma (decl:EConstr.compacted_declaration) =
+  let ids, pbody, typ = match decl with
+    | CompactedDecl.LocalAssum (ids, typ) ->
+       ids, None, typ
+    | CompactedDecl.LocalDef (ids,c,typ) ->
+       (* Force evaluation *)
+       let pb = pr_leconstr_env ~inctx:true env sigma c in
+       let pb = if EConstr.isCast sigma c then Pp.surround pb else pb in
+       ids, Some pb, typ in
+    let ids =
+      List.map (fun id -> Pp.string_of_ppcmds @@ Ppconstr.pr_id id.Context.binder_name) ids in
+    let body = Option.map Pp.string_of_ppcmds pbody in
+    let typ = pr_letype_env env sigma typ in
+    let _type = Pp.string_of_ppcmds typ in
+    {ids; body; _type} 
+
+let mk_goal env sigma g =
+  let EvarInfo evi = Evd.find sigma g in
+  let env = Evd.evar_filtered_env env evi in
+  let min_env = Environ.reset_context env in
+  let id = Evar.repr g in
+  let concl = match Evd.evar_body evi with
+  | Evar_empty -> Evd.evar_concl evi
+  | Evar_defined body -> Retyping.get_type_of env sigma body
+  in
+  let ccl =
+    pr_letype_env ~goal_concl_style:true env sigma concl
+  in
+  let mk_hyp d (env,l) =
+    let d' = CompactedDecl.to_named_context d in
+    let env' = List.fold_right EConstr.push_named d' env in
+    let Refl = EConstr.Unsafe.eq in
+    let hyp = mk_pp_hyp env sigma d in
+    (env', hyp :: l)
+  in
+  let (_env, hyps) =
+    Context.Compacted.fold mk_hyp
+      (Termops.compact_named_context sigma (EConstr.named_context env)) ~init:(min_env,[]) in
+  {
+    id;
+    hypotheses = List.rev hyps;
+    goal = Pp.string_of_ppcmds ccl;
+  }
+
+let proof_of_state st =
+  match st.Vernacstate.interp.lemmas with
+  | None -> None
+  | Some lemmas ->
+    Some (lemmas |> Vernacstate.LemmaStack.with_top ~f:Declare.Proof.get)
+
+(* The Rocq diff API is so poorly designed that we have to imperatively set a
+   string option to control the behavior of `mk_goal_diff`. We do the required
+   plumbing here. *)
+let string_of_diff_mode = function
+  | Settings.Goals.Diff.Mode.Off -> "off"
+  | On -> "on"
+  | Removed -> "removed"
+
+let set_diff_mode diff_mode =
+  Goptions.set_string_option_value Proof_diffs.opt_name @@ string_of_diff_mode diff_mode
+
+let get_proof st =
+  Vernacstate.unfreeze_full_state st;
+  match proof_of_state st with
+  | None -> None
+  | Some proof ->
+    let env = Global.env () in
+    let proof_data = Proof.data proof in
+    let b_goals = Proof.background_subgoals proof in
+    let sigma = proof_data.sigma in
+    let goals = List.map (mk_goal env sigma) proof_data.goals in
+    let unfocusedGoals = List.map (mk_goal env sigma) b_goals in
+    let shelvedGoals = List.map (mk_goal env sigma) (Evd.shelf sigma) in
+    let givenUpGoals = List.map (mk_goal env sigma) (Evar.Set.elements @@ Evd.given_up sigma) in
+    Some {
+      goals;
+      shelvedGoals;
+      givenUpGoals;
+      unfocusedGoals;
+    }

--- a/language-server/protocol/settings.ml
+++ b/language-server/protocol/settings.ml
@@ -123,9 +123,25 @@ module Goals = struct
 
   end
 
+  module PrettyPrint = struct
+    
+    type t = String | Pp
+
+    let t_of_yojson = function
+    | `String "String" -> String
+    | `String "Pp" -> Pp
+    | _ -> Yojson.json_error "invalid value"
+
+    let yojson_of_t = function
+    | String -> `String "String"
+    | Pp -> `String "Pp"
+
+  end
+
   type t = {
     diff: Diff.t;
     messages: Messages.t;
+    ppmode: PrettyPrint.t option;
   } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
 end

--- a/language-server/tests/common.ml
+++ b/language-server/tests/common.ml
@@ -159,7 +159,7 @@ let rec handle_dm_events n (events : DocumentManager.event Sel.Todo.t) st =
     | Some ev ->
       (* Stdlib.Format.eprintf "handle_dm_events: handling %a\n"  DocumentManager.pp_event ev; *)
       let st, new_events =
-        match DocumentManager.handle_event ev st ~block:false Protocol.Settings.Mode.Manual Protocol.Settings.Goals.Diff.Mode.Off with
+        match DocumentManager.handle_event ev st ~block:false Protocol.Settings.Mode.Manual Protocol.Settings.Goals.Diff.Mode.Off Protocol.Settings.Goals.PrettyPrint.Pp with
         | { DocumentManager.state = None; events = events' } -> st, events'
         | { DocumentManager.state = Some st; events = events' } -> st, events'
       in

--- a/language-server/tests/goals.ml
+++ b/language-server/tests/goals.ml
@@ -16,6 +16,7 @@ open Base
 open Dm
 open Common
 open Protocol
+open LspWrapper
 
 let%test_unit "goals: encoding after replay from top" =
   let st = dm_init_and_parse_test_doc ~text:"Lemma foo : forall x y, x + y = y + x." in
@@ -31,7 +32,8 @@ let%test_unit "goals: encoding after replay from top" =
   let st = handle_dm_events todo st in
   let proof = Stdlib.Option.get (DocumentManager.get_proof st Protocol.Settings.Goals.Diff.Mode.Off None) in
   let messages = DocumentManager.get_messages st (Option.value_exn @@ DocumentManager.Internal.observe_id st) in
-  let _json = Protocol.ExtProtocol.Notification.Server.ProofViewParams.yojson_of_t { proof = Some proof; messages } in
+  (*added bogus values for the other code path (getting everything as strings)*)
+  let _json = Protocol.ExtProtocol.Notification.Server.ProofViewParams.yojson_of_t { proof = Some proof; messages; pp_proof = None; pp_messages = []; range = Range.top() } in
   ()
 
 let%test_unit "goals: proof is available after error" =

--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -37,6 +37,8 @@ let states : (string, tab) Hashtbl.t = Hashtbl.create 39
 let check_mode = ref Settings.Mode.Manual
 
 let diff_mode = ref Settings.Goals.Diff.Mode.Off
+
+let pretty_print_mode = ref Settings.Goals.PrettyPrint.Pp
 let max_memory_usage  = ref 4000000000
 
 let full_diagnostics = ref false
@@ -131,7 +133,10 @@ let do_configuration settings =
   full_messages := settings.goals.messages.full;
   max_memory_usage := settings.memory.limit * 1000000000;
   block_on_first_error := settings.proof.block;
-  point_interp_mode := settings.proof.pointInterpretationMode
+  point_interp_mode := settings.proof.pointInterpretationMode;
+  match settings.goals.ppmode with
+  | None -> ()
+  | Some s -> pretty_print_mode := s
 
 let send_configuration_request () =
   let id = `Int conf_request_id in
@@ -649,7 +654,7 @@ let handle_event = function
       log (fun () -> "ignoring event on non-existing document");
       []
     | Some { st; visible } ->
-      let handled_event = Dm.DocumentManager.handle_event e st ~block:!block_on_first_error !check_mode !diff_mode in
+      let handled_event = Dm.DocumentManager.handle_event e st ~block:!block_on_first_error !check_mode !diff_mode !pretty_print_mode in
       let events = handled_event.events in
       begin match handled_event.state with
         | None -> ()


### PR DESCRIPTION
Now the server can be configured to return the formatted string instead of the pp. Additionally we return the range of the sentence corresponding to the rendered goal view.