### PR TITLE
Fix 1066

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -267,7 +267,7 @@ let add_sentence parsed parsing_start start stop (ast: sentence_state) synterp_s
   let scheduler_state_after, schedule = 
     match ast with
     | Error {msg} ->
-      scheduler_state_before, Scheduler.schedule_errored_sentence id msg parsed.schedule
+      scheduler_state_before, Scheduler.schedule_errored_sentence id msg synterp_state parsed.schedule
     | Parsed ast ->
       let ast' = (ast.ast, ast.classification, synterp_state) in
       Scheduler.schedule_sentence (id, ast') scheduler_state_before parsed.schedule
@@ -417,7 +417,7 @@ let patch_sentence parsed scheduler_state_before id ({ parsing_start; ast; start
   let scheduler_state_after, schedule =
     match ast with
     | Error {msg} ->
-      scheduler_state_before, Scheduler.schedule_errored_sentence id msg parsed.schedule
+      scheduler_state_before, Scheduler.schedule_errored_sentence id msg synterp_state parsed.schedule
     | Parsed ast ->
       let ast = (ast.ast, ast.classification, synterp_state) in
       Scheduler.schedule_sentence (id,ast) scheduler_state_before parsed.schedule

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -476,7 +476,7 @@ let rec diff old_sentences new_sentences =
 
 let string_of_diff_item doc = function
   | Deleted ids ->
-       ids |> List.map (fun id -> Printf.sprintf "- (id: %d) %s" (Stateid.to_int id) (string_of_parsed_ast (Option.get (get_sentence doc id)).ast))
+       ids |> List.map (fun id -> Printf.sprintf "- (id: %d) %s" (Stateid.to_int id) (try string_of_parsed_ast (Option.get (get_sentence doc id)).ast with Option.IsNone -> "missing from doc"))
   | Added sentences ->
        sentences |> List.map (fun (s : pre_sentence) -> Printf.sprintf "+ %s" (string_of_parsed_ast s.ast))
   | Equal l ->

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -32,7 +32,7 @@ type executable_sentence = {
 
 type task =
   | Skip of { id: sentence_id; error: Pp.t option }
-  | Block of { id: sentence_id; error: Pp.t Loc.located }
+  | Block of { id: sentence_id; synterp : Vernacstate.Synterp.t; error: Pp.t Loc.located }
   | Exec of executable_sentence
   | OpaqueProof of { terminator: executable_sentence;
                      opener_id: sentence_id;
@@ -223,8 +223,8 @@ let _string_of_state st =
   let scopes = (List.map (fun b -> List.map (fun x -> x.id) b.proof_sentences) st.proof_blocks) @ [st.document_scope] in
   String.concat "|" (List.map (fun l -> String.concat " " (List.map Stateid.to_string l)) scopes)
 
-let schedule_errored_sentence id error schedule =
-  let task = Block {id; error} in
+let schedule_errored_sentence id error synterp schedule =
+  let task = Block {id; synterp; error} in
   let tasks = SM.add id (None, task) schedule.tasks in
   let dependencies = SM.add id Stateid.Set.empty schedule.dependencies in
   {tasks; dependencies}

--- a/language-server/dm/scheduler.mli
+++ b/language-server/dm/scheduler.mli
@@ -37,7 +37,7 @@ type executable_sentence = {
 
 type task =
   | Skip of { id: sentence_id; error: Pp.t option }
-  | Block of { id: sentence_id; error: Pp.t Loc.located }
+  | Block of { id: sentence_id; synterp : Vernacstate.Synterp.t; error: Pp.t Loc.located }
   | Exec of executable_sentence
   | OpaqueProof of { terminator: executable_sentence;
                      opener_id: sentence_id;
@@ -52,7 +52,7 @@ type schedule
 
 val initial_schedule : schedule
 
-val schedule_errored_sentence : sentence_id -> Pp.t Loc.located -> schedule -> schedule
+val schedule_errored_sentence : sentence_id -> Pp.t Loc.located -> Vernacstate.Synterp.t -> schedule -> schedule
 
 val schedule_sentence : sentence_id * (Synterp.vernac_control_entry * Vernacextend.vernac_classification * Vernacstate.Synterp.t) -> state -> schedule -> state * schedule
 (** Identifies the structure of the document and dependencies between sentences


### PR DESCRIPTION
@rtetley See my last comment on the issue. I noticed that some piece of code does install the wrong synterp state. My guess is that if a "parse error" sentence gets executed it is promoted to a "exec error" sentence with a full (as in interp+synterp) state. That state, for reasons I could not fully undertand is the used to reparse the sentence, or is installed by someone else and the just re-installing the synterp state is not enough...).

I think my fix is just a safety-belt, one would need to understand more that causes the wrong state to be used for parsing.
I suspect also Skip sentences suffer the same.

Fix #1066