### PR TITLE
Update Readme for VsRocq

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,39 +3,38 @@
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 
-[action-shield]: https://github.com/coq/vscoq/actions/workflows/ci.yml/badge.svg?branch=main
-[action-link]: https://github.com/coq/vscoq/actions?query=workflow:ci
+[action-shield]: https://github.com/rocq-prover/vsrocq/actions/workflows/ci.yml/badge.svg?branch=main
+[action-link]: https://github.com/rocq-prover/vsrocq/actions?query=workflow:ci
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
-[contributing-link]: https://github.com/coq/vscoq/manifesto/blob/master/CONTRIBUTING.md
+[contributing-link]: https://github.com/rocq-prover/vsrocq/manifesto/blob/master/CONTRIBUTING.md
 
 [conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
-[conduct-link]: https://github.com/coq/vscoq/manifesto/blob/master/CODE_OF_CONDUCT.md
+[conduct-link]: https://github.com/rocq-prover/vsrocq/manifesto/blob/master/CODE_OF_CONDUCT.md
 
 [zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
-[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237662-VsCoq-devs.20.26.20users
+[zulip-link]: https://rocq-prover.zulipchat.com/#narrow/channel/237662-VsRocq-devs-.26-users
 
-VsCoq is an extension for [Visual Studio Code](https://code.visualstudio.com/)
-(VS Code) and [VSCodium](https://vscodium.com/) which provides support for the [Coq Proof
-Assistant](https://coq.inria.fr/). It is built around a language server which natively speaks the [LSP protocol](https://learn.microsoft.com/en-us/visualstudio/extensibility/language-server-protocol?view=vs-2022).
+VsRocq is an extension for [Visual Studio Code](https://code.visualstudio.com/)
+(VS Code) and [VSCodium](https://vscodium.com/) which provides support for the [Rocq Interactive Theorem Prover](https://rocq-prover.org/). It is built around a language server which natively speaks the [LSP protocol](https://learn.microsoft.com/en-us/visualstudio/extensibility/language-server-protocol?view=vs-2022).
 
-## Supported Coq versions
+## Supported Rocq versions
 
-**VsCoq** supports all recent Coq versions >= 8.18.
+**VsRocq** supports all recent Rocq/Coq versions >= 8.18.
 If you are running an Coq < 8.18 you should use [VsCoq Legacy](https://github.com/coq-community/vscoq-legacy).
 
-## Installing VsCoq
+## Installing VsRocq
 
-To use VsCoq, you need to (1) install the VsCoq language server
-and (2) install and configure the VsCoq extension in either VS Code or VSCodium.
+To use VsRocq, you need to (1) install the VsRocq language server
+and (2) install and configure the VsRocq extension in either VS Code or VSCodium.
 
 ### Installing the language server
 
-After creating an opam switch, pin Coq,
-and install the `vscoq-language-server` package:
+After creating an opam switch, pin Rocq,
+and install the `vsrocq-language-server` package:
 ```shell
-$ opam pin add coq 8.18.0
-$ opam install vscoq-language-server
+$ opam pin add rocq-core 9.1.0 # replace with correct version
+$ opam install vsrocq-language-server
 ```
 
 or on nixos
@@ -44,30 +43,31 @@ or on nixos
 nix profile install nixpkgs#coq_8_18 nixpkgs#coqPackages_8_18.vscoq-language-server
 ```
 
-After installation, check that you have `vscoqtop` in your shell
+After installation, check that you have `vsrocqtop` in your shell
 and note the path to this executable:
 ```shell
-$ which vscoqtop
+$ which vsrocqtop
 ```
+
 
 #### Pre-release versions
 
 We often roll out pre-release versions. To get the correct language server version please pin the git repo. For example,
-for pre-release ```v2.1.5```:
+for pre-release ```v2.3.1```:
 ```shell
-$ opam pin add vscoq-language-server.2.1.5  https://github.com/coq/vscoq/releases/download/v2.1.5/vscoq-language-server-2.1.5.tar.gz
+$ opam pin add vsrocq-language-server.2.3.1  https://github.com/rocq-prover/vsrocq/releases/download/v2.3.1/vsrocq-language-server-2.3.1.tar.gz
 ```
 
 ### Installing and configuring the extension
 
-To install the [VS Code](https://marketplace.visualstudio.com/items?itemName=maximedenes.vscoq)
-or [VSCodium extension](https://open-vsx.org/extension/maximedenes/vscoq), first run `code`
+To install the [VS Code](https://marketplace.visualstudio.com/items?itemName=rocq-prover.vsrocq)
+or [VSCodium extension](https://open-vsx.org/extension/rocq-prover/vsrocq), first run `code`
 or `codium`. Then press F1 to open the command palette, start typing
-"Extensions: Install Extension", press enter, and search for "vscoq". Switch to
+"Extensions: Install Extension", press enter, and search for "vsrocq". Switch to
 the **pre-release version** of the extension and enable it. Finally, go to the extension
-settings and enter the `vscoqtop` full path from above in the field "Vscoq: Path".
+settings and enter the `vsrocqtop` full path from above in the field "Vsrocq: Path".
 
-If you want asynchronous processing of Coq files, you can go to
+If you want asynchronous processing of Rocq files, you can go to
 the "Proof: Mode" and select "Continuous". Otherwise, processing will step by step and top-down as in VsCoq1.
 
 #### Pre-release versions
@@ -89,17 +89,17 @@ This could be due to an old ```vscode``` version. Make sure ```vscode``` is up t
 
 #### Getting help
 
-If you are unable to set-up vscoq, feel free to contact us on the ```Vscoq devs and users``` [channel in zulip](https://coq.zulipchat.com/#narrow/stream/237662-VsCoq-devs-.26-users).
+If you are unable to set-up vsrocq, feel free to contact us on the ```VsRocq Devs and Users``` [channel in zulip](https://rocq-prover.zulipchat.com/#narrow/channel/237662-VsRocq-devs-.26-users).
 
 ## Features
 * Syntax highlighting
 * Asynchronous proof checking
-* Continuous and incremental checking of Coq documents
+* Continuous and incremental checking of Rocq documents
 
-The new version of vscoq allows users to opt for continuous checking, see the goal panel update as you scroll or edit your document.
+Vsrocq allows users to opt for continuous checking, see the goal panel update as you scroll or edit your document.
 ![](gif/continuous-mode.gif)
 
-By default vscoq is configured to use classic step by step checking mode. 
+By default, vsrocq is configured to use classic step by step checking mode. 
 ![](gif/manual-mode.gif)
 
 * Customisable goal panel 
@@ -133,7 +133,7 @@ We now support a document outline, which displays theorems and definitions in th
 
 * Ellipsis for the goal panel
 
-Goals can now be ellided. First through the `"vscoq.goals.maxDepth"` setting which ellides a goal if the display becomes to large.
+Goals can now be ellided. First through the `"vsrocq.goals.maxDepth"` setting which ellides a goal if the display becomes to large.
 Finally by clicking on the goal view as showcased here.
 The following modifiers can be used: 
 - ```Alt + Click```: open/close an ellipsis (only opens partially).
@@ -141,10 +141,10 @@ The following modifiers can be used:
 
 ![](gif/goal-ellipsis.gif)
 
-* Quickfixes (only for Coq >= 8.21)
+* Quickfixes (only for Rocq/Coq >= 8.21)
 
-We have added support for quickfixes. However, quickfixes rely on some Coq API which will only make it in the 8.21 release.
-Developpers are encouraged to list and add their own quickfixes in the Coq source code.
+We have added support for quickfixes. However, quickfixes rely on some Rocq API which will only make it in the 8.21 release.
+Developpers are encouraged to list and add their own quickfixes in the Rocq source code.
 
 ![](gif/quickfix.gif)
 
@@ -158,41 +158,41 @@ We support the classic block on error mode, in which the execution of a document
 After installation and activation of the extension:
 
 (Press `F1` and start typing "settings" to open either workspace/project or user settings.)
-#### Coq configuration
-* `"vscoq.path": ""` -- specify the path to `vscoqtop` (e.g. `path/to/vscoq/bin/vscoqtop`)
-* `"vscoq.args": []` -- an array of strings specifying additional command line arguments for `vscoqtop` (typically accepts the same flags as `coqtop`)
-* `"vscoq-language-server.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
+#### Rocq configuration
+* `"vsrocq.path": ""` -- specify the path to `vsrocqtop` (e.g. `path/to/vsrocq/bin/vsrocqtop`)
+* `"vsrocq.args": []` -- an array of strings specifying additional command line arguments for `vsrocqtop` (typically accepts the same flags as `rocqtop`)
+* `"vsrocq-language-server.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
 
 #### Memory management (since >= 2.1.7)
-* `"vscoq.memory.limit: int` -- specifies the memory limit (in Gb) over which when a user closes a tab, the corresponding document state is discarded in the server to free up memory. Defaults to 4Gb.
+* `"vsrocq.memory.limit: int` -- specifies the memory limit (in Gb) over which when a user closes a tab, the corresponding document state is discarded in the server to free up memory. Defaults to 4Gb.
 
 #### Goal and info view panel
-* `"vscoq.goals.display": Tabs | List` -- Decide whether to display goals in separate tabs or as a list of collapsibles.
-* `"vscoq.goals.diff.mode": on | off | removed` -- Toggles diff mode. If set to `removed`, only removed characters are shown (defaults to `off`)
-* `"vscoq.goals.messages.full": bool` -- A toggle to include warnings and errors in the proof view (defaults to `false`)
-* `"vscoq.goals.maxDepth": int` -- A setting to determine at which point the goal display starts elliding. Defaults to 17. (since version >= 2.1.7)
+* `"vsrocq.goals.display": Tabs | List` -- Decide whether to display goals in separate tabs or as a list of collapsibles.
+* `"vsrocq.goals.diff.mode": on | off | removed` -- Toggles diff mode. If set to `removed`, only removed characters are shown (defaults to `off`)
+* `"vsrocq.goals.messages.full": bool` -- A toggle to include warnings and errors in the proof view (defaults to `false`)
+* `"vsrocq.goals.maxDepth": int` -- A setting to determine at which point the goal display starts elliding. Defaults to 17. (since version >= 2.1.7)
 
 #### Proof checking
-* `"vscoq.proof.mode": Continuous | Manual` -- Decide whether documents should checked continuously or using the classic navigation commmands (defaults to `Manual`)
-* `"vscoq.proof.pointInterpretationMode": Cursor | NextCommand` -- Determines the point to which the proof should be check to when using the 'Interpret to point' command. 
-* `"vscoq.proof.cursor.sticky": bool` -- a toggle to specify whether the cursor should move as Coq interactively navigates a document (step forward, backward, etc...)
-* `"vscoq.proof.delegation": None | Skip | Delegate` -- Decides which delegation strategy should be used by the server. 
+* `"vsrocq.proof.mode": Continuous | Manual` -- Decide whether documents should checked continuously or using the classic navigation commmands (defaults to `Manual`)
+* `"vsrocq.proof.pointInterpretationMode": Cursor | NextCommand` -- Determines the point to which the proof should be check to when using the 'Interpret to point' command. 
+* `"vsrocq.proof.cursor.sticky": bool` -- a toggle to specify whether the cursor should move as Rocq interactively navigates a document (step forward, backward, etc...)
+* `"vsrocq.proof.delegation": None | Skip | Delegate` -- Decides which delegation strategy should be used by the server. 
   `Skip` allows to skip proofs which are out of focus and should be used in manual mode. `Delegate` allocates a settable amount of workers
   to delegate proofs. 
-* `"vscoq.proof.workers": int` -- Determines how many workers should be used for proof checking
-* `"vscoq.proof.block": bool` -- Determines if the the execution of a document should halt on first error.  Defaults to true (since version >= 2.1.7).
-* `"vscoq.proof.display-buttons": bool` -- A toggle to control whether buttons related to Coq (step forward/back, reset, etc.) are displayed in the editor actions menu (defaults to `true`)
+* `"vsrocq.proof.workers": int` -- Determines how many workers should be used for proof checking
+* `"vsrocq.proof.block": bool` -- Determines if the the execution of a document should halt on first error.  Defaults to true (since version >= 2.1.7).
+* `"vsrocq.proof.display-buttons": bool` -- A toggle to control whether buttons related to Rocq (step forward/back, reset, etc.) are displayed in the editor actions menu (defaults to `true`)
 
 #### Code completion (experimental)
-* `"vscoq.completion.enable": bool` -- Toggle code completion (defaults to `false`)
-* `"vscoq.completion.algorithm": StructuredSplitUnification | SplitTypeIntersection` -- Which completion algorithm to use
-* `"vscoq.completion.unificationLimit": int` -- Sets the limit for how many theorems unification is attempted
+* `"vsrocq.completion.enable": bool` -- Toggle code completion (defaults to `false`)
+* `"vsrocq.completion.algorithm": StructuredSplitUnification | SplitTypeIntersection` -- Which completion algorithm to use
+* `"vsrocq.completion.unificationLimit": int` -- Sets the limit for how many theorems unification is attempted
 
 #### Diagnostics
-* `"vscoq.diagnostics.full": bool` -- Toggles the printing of `Info` level diagnostics (defaults to `false`)
+* `"vsrocq.diagnostics.full": bool` -- Toggles the printing of `Info` level diagnostics (defaults to `false`)
 
 ## For extension developers 
-See [Dev docs](https://github.com/coq/vscoq/blob/main/docs/developers.md)
+See [Dev docs](https://github.com/rocq-prover/vsrocq/blob/main/docs/developers.md)
 
 ## Maintainers
 
@@ -203,6 +203,8 @@ This extension is currently developed and maintained by
 ## License
 Unless mentioned otherwise, files in this repository are [distributed under the MIT License](LICENSE).
 
-The files `client/syntax/coq.tmLanguage` and `client/coq.configuration.json` are
-also distributed under the MIT License, Copyright (c) Christian J. Bell and
-contributors.
+The following files are also distributed under the MIT License, Copyright (c) Christian J. Bell and contributors:
+* `client/syntax/coq.tmLanguage.json`
+* `client/syntax/rocq.tmLanguage.json`
+* `client/coq.language-configuration.json`
+* `client/rocq.language-configuration.json`


### PR DESCRIPTION
It's called VsRocq now. No reason to confuse users by calling it VsCoq everywhere. I also updated old links, notably linking to the `rocq-prover.vsrocq` extension now.