### PR TITLE
nix-ci runs fatalwarnings profile on rocq master only on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         coq: [8-18, 8-19, 8-20, 9, 9-1, master]
-        profile: [dev, fatalwarnings]
+        profile: [dev]
+        include:
+          - profile: fatalwarnings
+            coq: master
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout


### PR DESCRIPTION
The fatalwarnings CI job is to detect deprecation warnings from rocq master.
It is pointless to run it on old version of rocq.
Moreover the test is platform agnostic, so we run it on linux only.
We run it on nix and opam, since the ocaml compiler may be different and emit a different set of warnings.