### PR TITLE
Fix minor typos/stale links in github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ""
 **IMPORTANT: Before You Submit This Issue**
 
 - [ ] I have searched the [existing VsRocq issues](https://github.com/rocq-prover/vsrocq/issues)
-- [ ] I have reviewed the [VsRocq FAQ.md](https://github.com/rocq-prover/vsrocq/blob/main/FAQ.md) and my issue is not addressed there.
+- [ ] I have reviewed the [VsRocq FAQ.md](https://github.com/rocq-prover/vsrocq/blob/main/docs/FAQ.md) and my issue is not addressed there.
 
 **Describe the Bug**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ""
 **IMPORTANT: Before You Submit This Feature Request**
 
 - [ ] I have searched the [existing VsRocq issues](https://github.com/rocq-prover/vsrocq/issues) to ensure this feature has not already been requested.
-- [ ] I have reviewed the [VsRocq FAQ.md](https://github.com/rocq-prover/vsrocq/blob/main/FAQ.md) to see if this relates to existing or planned functionality.
+- [ ] I have reviewed the [VsRocq FAQ.md](https://github.com/rocq-prover/vsrocq/blob/main/docs/FAQ.md) to see if this relates to existing or planned functionality.
 - [ ] I have checked the [VsRocq Roadmap](https://github.com/rocq-prover/vsrocq/wiki/The-VsCoq-VsRocq-roadmap-2024-2025) to see if this feature is already planned.
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
It's missing an `s`. Otherwise people try to report an issue, only to have their language server immediately crash.