### PR TITLE
Make goals.ppmode JSON key optional

### DIFF
--- a/language-server/protocol/settings.ml
+++ b/language-server/protocol/settings.ml
@@ -141,7 +141,7 @@ module Goals = struct
   type t = {
     diff: Diff.t [@default { mode = Diff.Mode.Off }];
     messages: Messages.t;
-    ppmode: PrettyPrint.t option;
+    ppmode: PrettyPrint.t option [@yojson.option];
   } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
 end


### PR DESCRIPTION
This PR makes the setting introduced by https://github.com/rocq-prover/vsrocq/commit/959482c39bbc764fd0210afb7a6388647f1f4d31 optional in the JSON serialization of `Settings.t`.
Currently, the key "ppmode" is always required, and its absence is an error (`None` is encoded by JSON `null`, not an absent key).
