### PR TITLE
feat: rm duplicate flake-utils in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
     rocq-master = { url = "github:rocq-prover/rocq/aeabefe987b1a9aa6bfcaa1ed44b4dcb9124c1d6"; }; # Should be kept in sync with PIN_COQ in CI workflow
     rocq-master.inputs.nixpkgs.follows = "nixpkgs";
-
+    rocq-master.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = {


### PR DESCRIPTION
Rocq also uses flake-utils in their flake.nix. This PR removes duplicated flake-utils by adding input follow. 