### PR TITLE
Fix string/bool type confusion in client/package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -145,7 +145,7 @@
           "vsrocq.goals.auto": {
             "scope": "window",
             "type": "boolean",
-            "default": "true",
+            "default": true,
             "description": "Should the goal view automatically display when navigating a rocq document."
           },
           "vsrocq.goals.display": {


### PR DESCRIPTION
This didn't cause issues because `"true"` is truthy in JS and this setting isn't read in OCaml.