### PR TITLE
Clean up print command in SearchViewProvider (#1225)

### DIFF
--- a/client/search-ui/src/App.tsx
+++ b/client/search-ui/src/App.tsx
@@ -74,6 +74,7 @@ const app = () => {
 
             case 'printResponse':
                 handlePrintNotification(msg.data.result);
+                break;
 
             case 'launchedSearch': 
                 //TODO: Add UI elements to show user the searching state

--- a/client/src/panels/SearchViewProvider.ts
+++ b/client/src/panels/SearchViewProvider.ts
@@ -230,8 +230,8 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
                         client.sendRequest(req, params).then(
                             (result: PrintRocqResponse) => {
                                 const notification = {"statement": result, "id": id};
-                                webview.postMessage({"command": "locateResponse", "result": notification});
-                            }, 
+                                webview.postMessage({"command": "printResponse", "result": notification});
+                            },
                             (err: QueryError) => {
                                 const error = {"code": err.code, "message": err.message};
                                 webview.postMessage({"command": "searchError", "error": error, "id": id});

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -627,9 +627,14 @@ let locate st pos ~pattern =
 let print st pos ~pattern = 
   let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   let sigma, env = get_context st pos in
-    let qid = parse_entry st loc (smart_global) pattern in
-    let udecl = None in (*TODO*)
-    Ok ( pp_of_rocqpp @@ print_name env sigma qid udecl )
+    try
+      let qid = parse_entry st loc (smart_global) pattern in
+      let udecl = None in (*TODO*)
+      Ok ( pp_of_rocqpp @@ print_name env sigma qid udecl )
+    with e ->
+      let e, info = Exninfo.capture e in
+      let message = Pp.string_of_ppcmds @@ CErrors.iprint (e, info) in
+      Error ({message; code=None})
 
 (* Ignore nested proofs option (lives in STM) instead of failing with
    anomaly when it is set in a .vo we Require.


### PR DESCRIPTION
I went to read the code when I saw @mattam82's issue.

* client/src/panels/SearchViewProvider.ts (_setWebviewMessageListener): Fix "command" in SearchViewProvider
* client/search-ui/src/App.tsx (handleMessage): Add missing `break` in `printResponse` case.
* language-server/dm/documentManager.ml (print): Wrap body in `try`/`with` to match `about` case.

Introduced in 3c447faf.  Amazingly, `Print` still works, because print responses have the same shape as `About` responses, so handling the former as the latter doesn't cause issues (but then perhaps the code shouldn't be duplicated?).

It might be better to refactor this to get rid of the duplicated code, though.