### PR TITLE
 feat[syntax]: add special handling for coq doc comments in syntax highlighting

### DIFF
--- a/client/syntax/coq.tmLanguage.json
+++ b/client/syntax/coq.tmLanguage.json
@@ -172,6 +172,23 @@
     },
     {
       "applyEndPatternLast": 1,
+      "begin": "\\(\\*\\*(?!\\*)",
+      "end": "\\*\\)",
+      "name": "comment.doc.coq",
+      "patterns": [
+        {
+          "include": "#doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#block_double_quoted_string"
+        }
+      ]
+    },
+    {
+      "applyEndPatternLast": 1,
       "begin": "\\(\\*(?!#)",
       "end": "\\*\\)",
       "name": "comment.block.coq",
@@ -214,6 +231,23 @@
     }
   ],
   "repository": {
+    "doc_comment": {
+      "applyEndPatternLast": 1,
+      "begin": "\\(\\*\\*(?!\\*)",
+      "end": "\\*\\)",
+      "name": "comment.doc.coq",
+      "patterns": [
+        {
+          "include": "#doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#block_double_quoted_string"
+        }
+      ]
+    },
     "block_comment": {
       "applyEndPatternLast": 1,
       "begin": "\\(\\*(?!#)",

--- a/client/syntax/rocq.tmLanguage.json
+++ b/client/syntax/rocq.tmLanguage.json
@@ -157,6 +157,23 @@
     },
     {
       "applyEndPatternLast": 1,
+      "begin": "\\(\\*\\*(?!\\*)",
+      "end": "\\*\\)",
+      "name": "comment.doc.rocq",
+      "patterns": [
+        {
+          "include": "#doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#block_double_quoted_string"
+        }
+      ]
+    },
+    {
+      "applyEndPatternLast": 1,
       "begin": "\\(\\*(?!#)",
       "end": "\\*\\)",
       "name": "comment.block.rocq",
@@ -199,6 +216,23 @@
     }
   ],
   "repository": {
+    "doc_comment": {
+      "applyEndPatternLast": 1,
+      "begin": "\\(\\*\\*(?!\\*)",
+      "end": "\\*\\)",
+      "name": "comment.doc.rocq",
+      "patterns": [
+        {
+          "include": "#doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#block_double_quoted_string"
+        }
+      ]
+    },
     "block_comment": {
       "applyEndPatternLast": 1,
       "begin": "\\(\\*(?!#)",


### PR DESCRIPTION
This PR adds simple handling for doc comment in the syntax highlighting.

<img width="405" height="145" alt="image" src="https://github.com/user-attachments/assets/baa9cb1a-4b2d-4d26-9772-860558dc89c2" />
