### PR TITLE
Restore hypothesis order in proofView

### DIFF
--- a/language-server/protocol/ppProofState.ml
+++ b/language-server/protocol/ppProofState.ml
@@ -85,7 +85,7 @@ let mk_goal env sigma g =
   {
     id;
     name;
-    hypotheses = List.rev hyps;
+    hypotheses = hyps;
     goal = Pp.string_of_ppcmds ccl;
   }
 

--- a/language-server/protocol/proofState.ml
+++ b/language-server/protocol/proofState.ml
@@ -75,7 +75,7 @@ let mk_goal env sigma g =
   {
     id;
     name;
-    hypotheses = List.rev_map pp_of_rocqpp hyps;
+    hypotheses = List.map pp_of_rocqpp hyps;
     goal = pp_of_rocqpp ccl;
   }
 

--- a/language-server/tests/goals.ml
+++ b/language-server/tests/goals.ml
@@ -44,3 +44,28 @@ let%test_unit "goals: proof is available after error" =
   let st = handle_dm_events todo st in
   let proof = DocumentManager.get_proof st None in
   [%test_eq: bool] true (Option.is_some proof)
+
+let%test_unit "goals: hypotheses are listed oldest-first" =
+  let open Stdlib.Option in
+  let st = dm_init_and_parse_test_doc ()
+    ~text:"Lemma foo (hyp_b: bool) (hyp_n: nat) : True." in
+  let st, _ = dm_parse st (P O) in
+  let exec_events = DocumentManager.interpret_to_end () in
+  let todo = Sel.Todo.(add empty exec_events) in
+  let st = handle_dm_events todo st in
+  let doc = DocumentManager.Internal.document st in
+  let sentence = get (Document.get_sentence doc (get (DocumentManager.Internal.observe_id st))) in
+  let vstate = get (Utilities.get_vernac_state sentence.checked) in
+
+  let pp_proof = get (Protocol.PpProofState.get_proof vstate) in
+  let pp_names = let open Protocol.PpProofState in
+    pp_proof.goals
+    |> List.concat_map ~f:(fun g -> g.hypotheses)
+    |> List.concat_map ~f:(fun h -> h.ids) in
+  [%test_eq: string list] [ "hyp_b"; "hyp_n" ] pp_names;
+
+  let proof = get (Protocol.ProofState.get_proof
+                     ~previous:None Protocol.Settings.Goals.Diff.Mode.Off vstate) in
+  let dump = Yojson.Safe.to_string (Protocol.ProofState.yojson_of_t proof) in
+  let idx pattern = String.substr_index_exn dump ~pattern in
+  [%test_eq: bool] true (idx "\"hyp_b\"" < idx "\"hyp_n\"")


### PR DESCRIPTION
Follow up to c2052b19, which flipped the order of hypotheses in `prover/proofView`.
Tagging @SkySkimmer for review