### PR TITLE
fix: synchronize first UI render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ocaml-compiler: [4.14.x]
+        ocaml-compiler: [4.14.2]
         coq: [8.18.0, 8.19.0, 8.20.0, 9.0.0, 9.1.1, 9.2.0, dev]
     runs-on: ${{ matrix.os }}
     steps:

--- a/client/goal-view-ui/src/App.tsx
+++ b/client/goal-view-ui/src/App.tsx
@@ -53,6 +53,7 @@ const app = () => {
 
     useEffect(() => {
         window.addEventListener("message", handleMessage);
+        vscode.postMessage({command: "pollGoals"});
         return () => {
             window.removeEventListener("message", handleMessage);
         };

--- a/client/goal-view-ui/src/index.tsx
+++ b/client/goal-view-ui/src/index.tsx
@@ -1,12 +1,17 @@
 import React from "react";
-import App from "./App";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
+import App from "./App";
 
 const container = document.getElementById("root")!;
 const root = createRoot(container);
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+// we make sure that the first render is synchronous, allowing us to immediately
+// send events to the webview without worrying about the component not being ready yet.
+flushSync(() => {
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+})

--- a/client/goal-view-ui/src/index.tsx
+++ b/client/goal-view-ui/src/index.tsx
@@ -1,17 +1,12 @@
 import React from "react";
-import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 
 const container = document.getElementById("root")!;
 const root = createRoot(container);
 
-// we make sure that the first render is synchronous, allowing us to immediately
-// send events to the webview without worrying about the component not being ready yet.
-flushSync(() => {
-  root.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-})
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/client/goal-view-ui/src/types.ts
+++ b/client/goal-view-ui/src/types.ts
@@ -42,3 +42,9 @@ export type GoalArray = Goal[];
 export type GoalArrayOrNull = Nullable<Goal[]>;
 
 export type ProofViewGoals = Nullable<ProofViewGoalsType>;
+
+export type VSCodeMessage = {
+    command: "openGoalSettings"
+} | {
+    command: "pollGoals"
+}

--- a/client/goal-view-ui/src/utilities/vscode.ts
+++ b/client/goal-view-ui/src/utilities/vscode.ts
@@ -1,4 +1,5 @@
 import type { WebviewApi } from "vscode-webview";
+import { VSCodeMessage } from "../types";
 
 /**
  * A utility wrapper around the acquireVsCodeApi() function, which enables
@@ -28,7 +29,7 @@ class VSCodeAPIWrapper {
    *
    * @param message Abitrary data (must be JSON serializable) to send to the extension context.
    */
-  public postMessage(message: unknown) {
+  public postMessage(message: VSCodeMessage): void {
     if (this.vsCodeApi) {
       this.vsCodeApi.postMessage(message);
     } else {

--- a/client/search-ui/src/index.tsx
+++ b/client/search-ui/src/index.tsx
@@ -1,12 +1,17 @@
 import React from "react";
-import App from "./App";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
+import App from "./App";
 
 const container = document.getElementById("root")!;
 const root = createRoot(container);
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+// we make sure that the first render is synchronous, allowing us to immediately
+// send events to the webview without worrying about the component not being ready yet.
+flushSync(() => {
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+})

--- a/client/search-ui/src/index.tsx
+++ b/client/search-ui/src/index.tsx
@@ -1,17 +1,12 @@
 import React from "react";
-import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 
 const container = document.getElementById("root")!;
 const root = createRoot(container);
 
-// we make sure that the first render is synchronous, allowing us to immediately
-// send events to the webview without worrying about the component not being ready yet.
-flushSync(() => {
-  root.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-})
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/client/src/panels/GoalPanel.ts
+++ b/client/src/panels/GoalPanel.ts
@@ -3,6 +3,7 @@ import { ProofViewNotification } from '../protocol/types';
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import Client from "../client";
+import type { VSCodeMessage } from "goal-view-ui/src/types";
 
 // /////////////////////////////////////////////////////////////////////////////
 // GOAL VIEW PANEL CODE
@@ -56,7 +57,7 @@ export default class GoalPanel {
    *
    * @param extensionUri The URI of the directory containing the extension.
    */
-  public static render(editor: TextEditor, extensionUri: Uri, callback?: (panel: GoalPanel) => any) {
+  public static render(editor: TextEditor, extensionUri: Uri) {
 
     //Get the correct view column
     let column = editor && editor.viewColumn ? editor.viewColumn + 1 : ViewColumn.Two;
@@ -88,10 +89,6 @@ export default class GoalPanel {
       );
 
       GoalPanel.currentPanel = new GoalPanel(panel, extensionUri);
-      if(callback) {
-        callback(GoalPanel.currentPanel);
-      }
-
     }
   }
 
@@ -149,31 +146,25 @@ export default class GoalPanel {
   }
 
   // /////////////////////////////////////////////////////////////////////////////
-  // Create the goal panel if it doesn't exit and then 
+  // Create the goal panel if it doesn't exist and then
   // handle a proofview notification
   // /////////////////////////////////////////////////////////////////////////////
   public static proofViewNotification(extensionUri: Uri, editor: TextEditor, pv: ProofViewNotification, autoDisplay: boolean) {
-    
+
     Client.writeToVsrocqChannel("[GoalPanel] Received proofview notification");
+    GoalPanel.currentPv = pv;
 
     if(!GoalPanel.currentPanel) {
         //If autoDisplay is set then render the proofview immediately
         if(autoDisplay) {
-            GoalPanel.render(editor, extensionUri, (goalPanel) => {
-                Client.writeToVsrocqChannel("[GoalPanel] Created new goal panel");
-                goalPanel._handleProofViewResponseOrNotification(pv);
-            });
-        }
-        //Otherwise record the current proofview notification to render on user prompt
-        else {
-            GoalPanel.currentPv = pv;
+            GoalPanel.render(editor, extensionUri);
         }
     }
     else {
         Client.writeToVsrocqChannel("[GoalPanel] Rendered in current panel");
-        GoalPanel.currentPanel._handleProofViewResponseOrNotification(pv);
+        GoalPanel.currentPanel._sendCurrentProofView();
     }
-    
+
   }
 
   public static displayProofView(extensionUri: Uri, editor: TextEditor) {
@@ -186,10 +177,14 @@ export default class GoalPanel {
     this._panel.webview.postMessage({ "command": "reset"});
   };
 
-  private _handleProofViewResponseOrNotification(pv: ProofViewNotification) {
-    this._panel.webview.postMessage({ "command": "renderProofView", "proofView": pv });
+  private _sendCurrentProofView() {
+    if (GoalPanel.currentPv) {
+        this._panel.webview.postMessage({ "command": "renderProofView", "proofView": GoalPanel.currentPv });
+    } else {
+        Client.writeToVsrocqChannel("[GoalPanel] No proof view to send");
+    }
   };
-  
+
   /**
    * Defines and returns the HTML that should be rendered within the webview panel.
    *
@@ -247,15 +242,20 @@ export default class GoalPanel {
    */
   private _setWebviewMessageListener(webview: Webview) {
     webview.onDidReceiveMessage(
-      (message: any) => {
+      (message: VSCodeMessage) => {
         const command = message.command;
-        const text = message.text;
 
         switch (command) {
             case 'openGoalSettings':
                 commands.executeCommand('workbench.action.openSettings', 'vsrocq.goals');
-            // Add more switch case statements here as more webview message commands
-            // are created within the webview context (i.e. inside media/main.js)
+                break;
+            case 'pollGoals':
+                if (GoalPanel.currentPanel) {
+                    GoalPanel.currentPanel._sendCurrentProofView();
+                } else {
+                    Client.writeToVsrocqChannel("[GoalPanel] No panel to send proof view to");
+                }
+                break;
         }
       },
       undefined,
@@ -263,4 +263,3 @@ export default class GoalPanel {
     );
   }
 }
- 


### PR DESCRIPTION
@gares this fixes the issue with the proof view not showing on first try.

vsrocq is operating under the assumption that once the HTML/JS was handed over to vscode, it will be synchronously rendered allowing us to immediately send a message to the webview by assuming that the UI has initialized all of the listeners. In react 18, this synchronous behavior has been retired. So the issue here was that react did not initialize listeners to receive the proof goals data.

In general the best fix would be to not assume this, as this is anyway a very strong assumption that in general does not hold true. But for now I just force a synchronous render at the very beginning just to make sure the listeners are initialized.