### PR TITLE
Add Event Emitter to access Proofview

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -531,6 +531,7 @@ Path: \`${rocqTM.getVsRocqTopPath()}\`
 
     const externalApi = {
         getDocumentProofs,
+        onProofStateChanged: GoalPanel.onProofStateChanged,
     };
 
     return externalApi;

--- a/client/src/panels/GoalPanel.ts
+++ b/client/src/panels/GoalPanel.ts
@@ -11,6 +11,7 @@ import {
     workspace,
 } from "vscode";
 import Client from "../client";
+import { EventEmitter } from "vscode";
 import { ProofViewNotification } from "../protocol/types";
 import { getNonce } from "../utilities/getNonce";
 import { getUri } from "../utilities/getUri";
@@ -32,6 +33,8 @@ import { getUri } from "../utilities/getUri";
 export default class GoalPanel {
     public static currentPanel: GoalPanel | undefined;
     public static currentPv: ProofViewNotification | undefined;
+    public static readonly _onProofStateChanged = new EventEmitter<ProofViewNotification>();
+    public static readonly onProofStateChanged = GoalPanel._onProofStateChanged.event;
     private readonly _panel: WebviewPanel;
     private _disposables: Disposable[] = [];
 
@@ -177,6 +180,7 @@ export default class GoalPanel {
             "[GoalPanel] Received proofview notification",
         );
         GoalPanel.currentPv = pv;
+        GoalPanel._onProofStateChanged.fire(pv);
 
         if (!GoalPanel.currentPanel) {
             //If autoDisplay is set then render the proofview immediately

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -256,3 +256,28 @@ type PrintRocqResponse = PpString;
 
 The verb `prover/interrupt` forces the interruption of Rocq interpreter. It
 takes an argument `textDocument` of type `VersionedTextDocumentIdentifier`.
+
+## External Extension API
+
+VSRocq exposes a public API that allows third-party extensions to access live proof state updates without spawning their own language server instance.
+
+The API is accessible via the VSCode extension API:
+
+```typescript
+const vsrocq = vscode.extensions.getExtension('rocq-prover.vsrocq');
+const api = await vsrocq.activate();
+```
+
+The `onProofStateChanged` event fires every time the proof state updates, e.g., when the user steps through a proof.
+
+```typescript
+api.onProofStateChanged((pv: ProofViewNotification) => {
+    // pv.proof.goals
+    // pv.proof.shelvedGoals
+    // pv.proof.givenUpGoals
+    // pv.proof.unfocusedGoals
+    // pv.messages (e.g. idtac output)
+});
+```
+
+`pv.proof` is `null` when the cursor is outside a proof. Proof state data is provided as the nested array `PpString` and can be converted to plain text using the `stringOfPpString` function in `client/pp-display/src/utilities.ts`.


### PR DESCRIPTION
Hi,
I am an undergraduate researcher building a proof visualization VSCode extension for ZX-Calculus using string diagrams. These changes add a public onProofStateChanged event to VSRocq API so the extension can access live proof state updates. This partially resolves #1222. I'm happy to discuss the changes.