### PR TITLE
feat: textDocument/highlight

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -167,6 +167,10 @@ let tokens_of_sentence (sentence: sentence) =
   | Error _ -> []
   | Parsed { tokens } -> tokens
 
+let token_at_loc sentence loc =
+  let contains (Loc.{ bp; ep }) = bp <= loc && loc <= ep in
+  List.find_opt (fun (token_loc, _) -> contains token_loc) (tokens_of_sentence sentence) |> Option.map snd
+
 let string_of_id document id =
   match SM.find_opt id document.sentences_by_id with
   | None -> CErrors.anomaly Pp.(str"Trying to get range of non-existing sentence " ++ Stateid.print id)

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -51,7 +51,7 @@ type outline = outline_element list
 type parsed_ast = {
   ast: Synterp.vernac_control_entry;
   classification: Vernacextend.vernac_classification;
-  tokens: (Range.t * Tok.t) list
+  tokens: (Loc.t * Tok.t) list
 }
 
 type comment = {
@@ -368,7 +368,6 @@ let find_sentence_before parsed loc =
   | Some (_, sentence_id) -> Some (sentence_of_id parsed sentence_id)
   | _ -> None
 
-(* moved here from DM, maybe can be simplified / use find_sentence_after *)
 let find_sentence_before_pos document pos =
   let loc = RawDocument.loc_of_position (raw_document document) pos in
   find_sentence_before document loc
@@ -745,7 +744,7 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
       let str = String.sub (RawDocument.text raw) begin_char (end_char - begin_char) in
       let sstr = Stream.of_string str in
       let lex = CLexer.Lexer.tok_func sstr in
-      let tokens = List.map (fun (loc, tok) -> (RawDocument.range_of_loc raw loc, tok)) @@ stream_tok 0 [] lex ast_loc in
+      let tokens = stream_tok 0 [] lex ast_loc in
       begin
         try
           log (fun () -> "Parsed: " ^ (Pp.string_of_ppcmds @@ Ppvernac.pr_vernac ast));

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -161,6 +161,12 @@ let range_of_sentence_with_blank_space raw (sentence : sentence) =
   let end_ = RawDocument.position_of_loc raw sentence.stop in
   Range.{ start; end_ }
 
+let tokens_of_sentence (sentence: sentence) =
+  match sentence.ast with
+  (* TODO: we could collect (best-effort) tokens for failed paring too *)
+  | Error _ -> []
+  | Parsed { tokens } -> tokens
+
 let string_of_id document id =
   match SM.find_opt id document.sentences_by_id with
   | None -> CErrors.anomaly Pp.(str"Trying to get range of non-existing sentence " ++ Stateid.print id)

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -51,7 +51,7 @@ type outline = outline_element list
 type parsed_ast = {
   ast: Synterp.vernac_control_entry;
   classification: Vernacextend.vernac_classification;
-  tokens: Tok.t list
+  tokens: (Range.t * Tok.t) list
 }
 
 type comment = {
@@ -515,9 +515,9 @@ let shift_sentence ~start ~offset s =
 let shift_feedbacks_and_checking_errors ~start ~offset parsed =
   { parsed with sentences_by_id = SM.map (shift_sentence ~start ~offset) parsed.sentences_by_id }
 
-let string_of_parsed_ast { tokens } = 
+let string_of_parsed_ast { tokens } =
   (* TODO implement printer for vernac_entry *)
-  "[" ^ String.concat "--" (List.map (Tok.extract_string false) tokens) ^ "]"
+  "[" ^ String.concat "--" (List.map (fun (_, tok) -> Tok.extract_string false tok) tokens) ^ "]"
 
 let string_of_parsed_ast = function
 | Error e -> "[errored sentence]: " ^ (e.str)
@@ -570,7 +570,7 @@ let same_tokens (s1 : sentence) (s2 : pre_sentence) =
   match s1.ast, s2.ast with
   | Error e1, Error e2 -> same_errors e1 e2
   | Parsed ast1, Parsed ast2 ->
-    CList.equal tok_equal ast1.tokens ast2.tokens
+    CList.equal tok_equal (List.map snd ast1.tokens) (List.map snd ast2.tokens)
   | _, _ -> false
   
 (* TODO improve diff strategy (insertions,etc) *)
@@ -608,21 +608,25 @@ let string_of_diff doc l =
 [%%endif]
 
 [%%if rocq = "8.18" || rocq = "8.19" || rocq = "8.20" || rocq = "9.0" || rocq = "9.1"]
-let rec stream_tok n_tok acc str begin_line begin_char =
+let rec stream_tok n_tok acc str (start_loc: Loc.t) =
   let e = LStream.next (get_keyword_state ()) str in
   match e with
   | Tok.EOI ->
     List.rev acc
   | _ ->
-    stream_tok (n_tok+1) (e::acc) str begin_line begin_char
+    let tok_loc = LStream.get_loc n_tok str in
+    let loc = Loc.shift_loc start_loc.bp start_loc.bp tok_loc in
+    stream_tok (n_tok+1) ((loc, e)::acc) str start_loc
 [%%else]
-let rec stream_tok n_tok acc str begin_line begin_char =
+let rec stream_tok n_tok acc str (start_loc: Loc.t) =
   let e = LStream.next (get_keyword_state ()) str in
   match e with
   | Some Tok.EOI ->
     List.rev acc
   | Some e ->
-    stream_tok (n_tok+1) (e::acc) str begin_line begin_char
+    let tok_loc = LStream.get_loc n_tok str in
+    let loc = Loc.shift_loc start_loc.bp start_loc.bp tok_loc in
+    stream_tok (n_tok+1) ((loc, e)::acc) str start_loc
   | None -> assert false (* should get EOI before None *)
 [%%endif]
     (*
@@ -727,15 +731,15 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
     | Some ast, comments ->
       let id = Stateid.fresh () in
       let stop = Stream.count stream in
-      let begin_line, begin_char, end_char =
-              match ast.loc with
-              | Some lc -> lc.line_nb, lc.bp, lc.ep
-              | None -> assert false
+      let ast_loc = match ast.loc with
+        | Some lc -> lc
+        | None -> assert false
       in
+      let begin_char, end_char = ast_loc.bp, ast_loc.ep in
       let str = String.sub (RawDocument.text raw) begin_char (end_char - begin_char) in
       let sstr = Stream.of_string str in
       let lex = CLexer.Lexer.tok_func sstr in
-      let tokens = stream_tok 0 [] lex begin_line begin_char in
+      let tokens = List.map (fun (loc, tok) -> (RawDocument.range_of_loc raw loc, tok)) @@ stream_tok 0 [] lex ast_loc in
       begin
         try
           log (fun () -> "Parsed: " ^ (Pp.string_of_ppcmds @@ Ppvernac.pr_vernac ast));

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -163,7 +163,7 @@ let range_of_sentence_with_blank_space raw (sentence : sentence) =
 
 let tokens_of_sentence (sentence: sentence) =
   match sentence.ast with
-  (* TODO: we could collect (best-effort) tokens for failed paring too *)
+  (* TODO: we could collect (best-effort) tokens for failed parsing too *)
   | Error _ -> []
   | Parsed { tokens } -> tokens
 

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -617,25 +617,25 @@ let string_of_diff doc l =
 [%%endif]
 
 [%%if rocq = "8.18" || rocq = "8.19" || rocq = "8.20" || rocq = "9.0" || rocq = "9.1"]
-let rec stream_tok n_tok acc str (start_loc: Loc.t) =
+let rec stream_tok acc str (start_loc: Loc.t) =
   let e = LStream.next (get_keyword_state ()) str in
   match e with
   | Tok.EOI ->
     List.rev acc
   | _ ->
-    let tok_loc = LStream.get_loc n_tok str in
+    let tok_loc = LStream.current_loc str in
     let loc = Loc.shift_loc start_loc.bp start_loc.bp tok_loc in
-    stream_tok (n_tok+1) ((loc, e)::acc) str start_loc
+    stream_tok ((loc, e)::acc) str start_loc
 [%%else]
-let rec stream_tok n_tok acc str (start_loc: Loc.t) =
+let rec stream_tok acc str (start_loc: Loc.t) =
   let e = LStream.next (get_keyword_state ()) str in
   match e with
   | Some Tok.EOI ->
     List.rev acc
   | Some e ->
-    let tok_loc = LStream.get_loc n_tok str in
+    let tok_loc = LStream.current_loc str in
     let loc = Loc.shift_loc start_loc.bp start_loc.bp tok_loc in
-    stream_tok (n_tok+1) ((loc, e)::acc) str start_loc
+    stream_tok ((loc, e)::acc) str start_loc
   | None -> assert false (* should get EOI before None *)
 [%%endif]
     (*
@@ -748,7 +748,7 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
       let str = String.sub (RawDocument.text raw) begin_char (end_char - begin_char) in
       let sstr = Stream.of_string str in
       let lex = CLexer.Lexer.tok_func sstr in
-      let tokens = stream_tok 0 [] lex ast_loc in
+      let tokens = stream_tok [] lex ast_loc in
       begin
         try
           log (fun () -> "Parsed: " ^ (Pp.string_of_ppcmds @@ Ppvernac.pr_vernac ast));

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -146,6 +146,9 @@ val sentences_sorted_by_loc : document -> sentence list
 val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
 
+val tokens_of_sentence : sentence -> (Range.t * Tok.t) list
+(** [tokens_of_sentence sentence] returns the list of tokens for the given sentence *)
+
 val find_sentence : document -> int -> sentence option
 (** [find_sentence doc loc] finds the sentence containing the loc *)
 

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -150,6 +150,9 @@ val sentences_before : document -> int -> sentence list
 val tokens_of_sentence : sentence -> (Loc.t * Tok.t) list
 (** [tokens_of_sentence sentence] returns the list of tokens for the given sentence *)
 
+val token_at_loc : sentence -> int -> Tok.t option
+(** [token_at_loc sentence loc] returns the token at the given location in the sentence, if any *)
+
 val find_sentence : document -> int -> sentence option
 (** [find_sentence doc loc] finds the sentence containing the loc *)
 

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -82,7 +82,7 @@ val handle_event : document -> event -> document * events * parsing_end_info opt
 type parsed_ast = {
   ast: Synterp.vernac_control_entry;
   classification: Vernacextend.vernac_classification;
-  tokens: Tok.t list
+  tokens: (Range.t * Tok.t) list
 }
 
 type parsing_error = {

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -82,7 +82,8 @@ val handle_event : document -> event -> document * events * parsing_end_info opt
 type parsed_ast = {
   ast: Synterp.vernac_control_entry;
   classification: Vernacextend.vernac_classification;
-  tokens: (Range.t * Tok.t) list
+  tokens: (Loc.t * Tok.t) list
+  (** The token ranges are absolute to the entire document *)
 }
 
 type parsing_error = {
@@ -146,7 +147,7 @@ val sentences_sorted_by_loc : document -> sentence list
 val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
 
-val tokens_of_sentence : sentence -> (Range.t * Tok.t) list
+val tokens_of_sentence : sentence -> (Loc.t * Tok.t) list
 (** [tokens_of_sentence sentence] returns the list of tokens for the given sentence *)
 
 val find_sentence : document -> int -> sentence option

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -450,7 +450,10 @@ let jump_to_definition st pos =
   QueryManager.jump_to_definition ~doc_id:(Document.id st.document) ~vs opattern
 let hover st pos =
   QueryManager.hover st.document pos
- 
+
+let highlight st pos =
+  QueryManager.highlight st.document pos
+
 let about st pos ~pattern =
   let vs = rocq_state_for st pos in
   QueryManager.about ~doc_id:(Document.id st.document) ~vs ~pattern

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -445,9 +445,9 @@ let check st pos ~pattern =
   QueryManager.check ~doc_id:(Document.id st.document) ~vs ~pattern
 
 let jump_to_definition st pos =
-  let opattern = RawDocument.word_at_position (Document.raw_document st.document) pos in
   let vs = rocq_state_for st pos in
-  QueryManager.jump_to_definition ~doc_id:(Document.id st.document) ~vs opattern
+  QueryManager.jump_to_definition st.document vs pos
+
 let hover st pos =
   QueryManager.hover st.document pos
 

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -121,6 +121,8 @@ val hover : state -> Position.t -> MarkupContent.t option
     if None, the position did not have a word,
     if Some, an Ok/Error result is returned. *)
 
+val highlight : state -> Position.t -> Range.t list
+
 val jump_to_definition : state -> Position.t -> (Range.t * string) option
 
 val check : state -> Position.t -> pattern:string -> (pp,error) Result.t

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -160,10 +160,11 @@ let hover document pos =
       | _ -> None
 
 (* Within a list of tokens, find all that are an identifier whose name is `ident` *)
-let find_all_ident (tokens: (Range.t * Tok.t) list) (ident: string) : Range.t list =
-  List.filter_map (fun (range, tok) ->
+let find_all_ident (tokens: (Loc.t * Tok.t) list) (ident: string) : Loc.t list =
+  List.filter_map (fun (loc, tok) ->
     match tok with
-    | Tok.IDENT s when s = ident -> Some range
+    | Tok.IDENT s
+    | Tok.FIELD s when s = ident -> Some loc
     | _ -> None) tokens
 
 (* We perform syntactic highlight of all identifiers that the same as the word at `pos` *)

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -159,8 +159,24 @@ let hover document pos =
         hover_of_sentence pattern (Document.find_next_qed_pos document pos)
       | _ -> None
 
-(* FIXME: implement feature *)
-let highlight document pos = []
+(* Within a list of tokens, find all that are an identifier whose name is `ident` *)
+let find_all_ident (tokens: (Range.t * Tok.t) list) (ident: string) : Range.t list =
+  List.filter_map (fun (range, tok) ->
+    match tok with
+    | Tok.IDENT s when s = ident -> Some range
+    | _ -> None) tokens
+
+(* We perform syntactic highlight of all identifiers that the same as the word at `pos` *)
+let highlight document pos =
+  let raw = Document.raw_document document in
+  let loc = RawDocument.loc_of_position raw pos in
+  let opattern = RawDocument.word_at_position raw pos in
+  match opattern with
+  | None -> log (fun () -> "highlight: no word found at cursor"); []
+  | Some pattern ->
+  log (fun () -> "highlight: found word at cursor: \"" ^ pattern ^ "\"");
+  let sentences = Document.sentences document in
+  find_all_ident (List.concat_map Document.tokens_of_sentence sentences) pattern
 
 [%%if rocq ="8.18" || rocq ="8.19" || rocq ="8.20"]
 let jump_to_definition ~vs:_ _ = None

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -176,13 +176,17 @@ let find_all_ident (tokens: (Loc.t * Tok.t) list) (ident: string) : Loc.t list =
 let highlight document pos =
   let raw = Document.raw_document document in
   let loc = RawDocument.loc_of_position raw pos in
-  let opattern = RawDocument.word_at_position raw pos in
-  match opattern with
-  | None -> log (fun () -> "highlight: no word found at cursor"); []
-  | Some pattern ->
-  log (fun () -> "highlight: found word at cursor: \"" ^ pattern ^ "\"");
-  let sentences = Document.sentences document in
-  find_all_ident (List.concat_map Document.tokens_of_sentence sentences) pattern
+  let osentence = Document.find_sentence document loc in
+  let otoken = Option.bind osentence (fun s -> Document.token_at_loc s loc) in
+  match otoken with
+  | None -> log (fun () -> "highlight: no item found at cursor"); []
+  | Some (Tok.IDENT pattern) | Some (Tok.FIELD pattern) ->
+    log (fun () -> "highlight: found token at cursor: \"" ^ pattern ^ "\"");
+    let sentences = Document.sentences document in
+    let tokens = List.concat_map Document.tokens_of_sentence sentences in
+    let locs = find_all_ident tokens pattern in
+    List.map (RawDocument.range_of_loc raw) locs
+  | Some token -> log (fun () -> "highlight: token at cursor is not an identifier: " ^ Tok.extract_string false token); []
 
 [%%if rocq ="8.18" || rocq ="8.19" || rocq ="8.20"]
 let jump_to_definition _ _ _ = None

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -159,6 +159,9 @@ let hover document pos =
         hover_of_sentence pattern (Document.find_next_qed_pos document pos)
       | _ -> None
 
+(* FIXME: implement feature *)
+let highlight document pos = []
+
 [%%if rocq ="8.18" || rocq ="8.19" || rocq ="8.20"]
 let jump_to_definition ~vs:_ _ = None
 [%%else]
@@ -283,6 +286,10 @@ let hover document pos =
   ProverThread.try_run ~doc_id:(Document.id document) ~name:"hover" ~timeout
     (fun () -> hover document pos) |>
   to_option |> Option.flatten
+
+let highlight document pos =
+  ProverThread.try_run ~doc_id:(Document.id document) ~name:"highlight" ~timeout
+    (fun () -> highlight document pos) |> to_list
 
 let about ~doc_id ~vs ~pattern =
   ProverThread.try_run ~doc_id ~name:"about" ~timeout (fun () -> about vs ~pattern) |>

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -134,10 +134,15 @@ let hover document pos =
        e.g. Definition, Inductive
      - At the next QED (for symbols defined after proof), if the next sentence 
        is in proof mode e.g. Lemmas, Definition with tactics *)
-  let opattern = RawDocument.word_at_position (Document.raw_document document) pos in
-  match opattern with
-  | None -> log (fun () -> "hover: no word found at cursor"); None
-  | Some pattern ->
+  let raw = Document.raw_document document in
+  let loc = RawDocument.loc_of_position raw pos in
+  let opattern = RawDocument.word_at_loc raw loc in
+  let osentence = Document.find_sentence document loc in
+  let otoken = Option.bind osentence (fun s -> Document.token_at_loc s loc) in
+  match opattern, otoken with
+  (* if the location has no associated token (eg. a comment) or it is a string literal, we ignore it *)
+  | None, _ | _, None | _, Some (Tok.STRING _) -> log (fun () -> "hover: no hoverable item found at cursor"); None
+  | Some pattern, _ ->
     log (fun () -> "hover: found word at cursor: \"" ^ pattern ^ "\"");
     (* hover at previous sentence *)
     match hover_of_sentence pattern (Document.find_sentence_before_pos document pos) with
@@ -180,13 +185,19 @@ let highlight document pos =
   find_all_ident (List.concat_map Document.tokens_of_sentence sentences) pattern
 
 [%%if rocq ="8.18" || rocq ="8.19" || rocq ="8.20"]
-let jump_to_definition ~vs:_ _ = None
+let jump_to_definition _ _ _ = None
 [%%else]
-let jump_to_definition ~vs opattern  =
+let jump_to_definition document vs pos  =
   let _side_effect_needed_ = context_of_vernac_state vs in
-  match opattern with
-  | None -> log (fun () -> "jumpToDef: no word found at cursor"); None
-  | Some pattern ->
+  let raw = Document.raw_document document in
+  let loc = RawDocument.loc_of_position raw pos in
+  let opattern = RawDocument.word_at_loc raw loc in
+  let osentence = Document.find_sentence document loc in
+  let otoken = Option.bind osentence (fun s -> Document.token_at_loc s loc) in
+  match opattern, otoken with
+  (* if the location has no associated token (eg. a comment) or it is a string literal, we ignore it *)
+  | None, _ | _, None | _, Some (Tok.STRING _) -> log (fun () -> "jumpToDef: no jumpable item found at cursor"); None
+  | Some pattern, _ ->
     log (fun () -> "jumpToDef: found word at cursor: \"" ^ pattern ^ "\"");
     try
     let qid = parse_entry vs (Procq.Prim.qualid) pattern in
@@ -283,8 +294,9 @@ let check ~doc_id ~vs ~pattern =
   ProverThread.try_run ~doc_id ~name:"check" ~timeout (fun () -> check ~vs ~pattern) |>
   to_types_error
 
-let jump_to_definition ~doc_id ~vs opattern =
-  ProverThread.try_run ~doc_id ~name:"jump_to_definition" ~timeout (fun () -> jump_to_definition ~vs opattern) |>
+let jump_to_definition document vs pos =
+  ProverThread.try_run ~doc_id:(Document.id document) ~name:"jump_to_definition" ~timeout
+    (fun () -> jump_to_definition document vs pos) |>
   to_option |> Option.flatten
 
 let locate ~doc_id ~vs ~pattern =

--- a/language-server/dm/queryManager.ml
+++ b/language-server/dm/queryManager.ml
@@ -164,7 +164,7 @@ let hover document pos =
         hover_of_sentence pattern (Document.find_next_qed_pos document pos)
       | _ -> None
 
-(* Within a list of tokens, find all that are an identifier whose name is `ident` *)
+(* Within a list of tokens, find all that are identifiers whose name is `ident` *)
 let find_all_ident (tokens: (Loc.t * Tok.t) list) (ident: string) : Loc.t list =
   List.filter_map (fun (loc, tok) ->
     match tok with
@@ -172,7 +172,7 @@ let find_all_ident (tokens: (Loc.t * Tok.t) list) (ident: string) : Loc.t list =
     | Tok.FIELD s when s = ident -> Some loc
     | _ -> None) tokens
 
-(* We perform syntactic highlight of all identifiers that the same as the word at `pos` *)
+(* We perform syntactic highlight of all identifiers that are the same as the word at `pos` *)
 let highlight document pos =
   let raw = Document.raw_document document in
   let loc = RawDocument.loc_of_position raw pos in

--- a/language-server/dm/queryManager.mli
+++ b/language-server/dm/queryManager.mli
@@ -49,6 +49,11 @@ val hover :
   Lsp.Types.MarkupContent.t option
 (** this one is a bit special since it crawls the document *)
 
+val highlight :
+  Document.document ->
+  Lsp.Types.Position.t ->
+  Lsp.Types.Range.t list
+
 val jump_to_definition :
   doc_id:int ->
   vs:Vernacstate.t ->

--- a/language-server/dm/queryManager.mli
+++ b/language-server/dm/queryManager.mli
@@ -55,9 +55,9 @@ val highlight :
   Lsp.Types.Range.t list
 
 val jump_to_definition :
-  doc_id:int ->
-  vs:Vernacstate.t ->
-  string option ->
+  Document.document ->
+  Vernacstate.t ->
+  Lsp.Types.Position.t ->
   (Lsp.Types.Range.t * string) option
 
 val get_completions :

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -86,10 +86,10 @@ let range_of_loc raw loc =
     end_ = position_of_loc raw loc.Loc.ep;
   }
 
-let word_at_position raw pos : string option =
+let word_at_loc raw loc : string option =
   try
     let back_reg = Str.regexp {|[^a-zA-Z_0-9.']|} in
-    let start_ind = loc_of_position raw pos in
+    let start_ind = loc in
     (* Search backwards until we find a character that cannot be part of a word *)
     let first_non_word_ind = Str.search_backward back_reg raw.text start_ind in
     let first_word_ind = first_non_word_ind + 1 in

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -25,7 +25,7 @@ val loc_of_position : t -> Position.t -> int
 val end_loc : t -> int
 
 val range_of_loc : t -> Loc.t -> Range.t
-val word_at_position: t -> Position.t -> string option
+val word_at_loc: t -> int -> string option
 val string_in_range: t -> int -> int -> string
 
 (** Applies a text edit, and returns start location *)

--- a/language-server/tests/callgraph/run.t
+++ b/language-server/tests/callgraph/run.t
@@ -17,6 +17,7 @@ Calls sequentialized via ProverThread APIs
   handle_event -> Dm.CheckingManager.handle_event -> Dm.ProverThread.try_run -> *
   handle_event -> Dm.Document.handle_event -> Dm.Document.create_parse_event -> Dm.ProverThread.eventually_run -> *
   handle_event -> Dm.Document.validate_document -> Dm.Document.create_parse_event -> Dm.ProverThread.eventually_run -> *
+  highlight -> Dm.QueryManager.highlight -> Dm.ProverThread.try_run -> [thunk] -> *
   hover -> Dm.QueryManager.hover -> Dm.ProverThread.try_run -> [thunk] -> *
   init -> start_library -> Dm.ProverThread.run -> *
   jump_to_definition -> Dm.QueryManager.jump_to_definition -> Dm.ProverThread.try_run -> [thunk] -> *

--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -317,9 +317,6 @@ let textDocumentDidChange params =
       update_view uri st;
       inject_dm_events (uri, events)
 
-let textDocumentDidSave params =
-  [] (* TODO handle properly *)
-
 let current_memory_usage () =
   let { Gc.heap_words; _ } = Gc.stat () in
   Sys.word_size * heap_words

--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -156,6 +156,7 @@ let do_initialize id params =
   let textDocumentSync = `TextDocumentSyncKind TextDocumentSyncKind.Incremental in
   let completionProvider = CompletionOptions.create ~resolveProvider:false () in
   let documentSymbolProvider = `DocumentSymbolOptions (DocumentSymbolOptions.create ~workDoneProgress:true ()) in
+  let documentHighlightProvider = `Bool true in
   let hoverProvider = `Bool true in
   let definitionProvider = `Bool true in
   let capabilities = ServerCapabilities.create
@@ -164,6 +165,7 @@ let do_initialize id params =
     ~hoverProvider
     ~definitionProvider
     ~documentSymbolProvider
+    ~documentHighlightProvider
   ()
   in
   let initialize_result = Lsp.Types.InitializeResult.{
@@ -363,6 +365,15 @@ let textDocumentHover id params =
     | Some contents -> Ok (Some (Hover.create ~contents:(`MarkupContent contents) ()))
     | _ -> Ok None (* FIXME handle error case properly *)
 
+let textDocumentHighlight id params =
+  let Lsp.Types.DocumentHighlightParams.{ textDocument; position } = params in
+  let open Yojson.Safe.Util in
+  match Hashtbl.find_opt states (DocumentUri.to_path textDocument.uri) with
+  | None -> log (fun () -> "[textDocumentHighlight] ignoring event on non existing document"); Ok None (* FIXME handle error case properly *)
+  | Some { st } ->
+    let ranges = Dm.DocumentManager.highlight st position in
+    Ok (Some (List.map (fun range -> DocumentHighlight.create ~range:range ()) ranges))
+
 let textDocumentDefinition params =
   let Lsp.Types.DefinitionParams.{ textDocument; position } = params in
   match Hashtbl.find_opt states (DocumentUri.to_path textDocument.uri) with
@@ -550,6 +561,8 @@ let dispatch_std_request : type a. Jsonrpc.Id.t -> a Lsp.Client_request.t -> (a,
     textDocumentDefinition params, []
   | TextDocumentHover params ->
     textDocumentHover id params, []
+  | TextDocumentHighlight params ->
+    textDocumentHighlight id params, []
   | DocumentSymbol params ->
     documentSymbol id params
   | UnknownRequest _ | _  -> Error ({message="Received unknown request"; code=None}), []


### PR DESCRIPTION
This LSP request sends a cursor position and expects a list of ranges to be returned that should be highlighted. Usually, LSPs return highlights that correspond to the items semantically equal to the item at the cursor. VsCode sends the `textDocument/highlight` request every time the cursor moves. If an LSP does not implement this request, by default VsCode will highlight all words in the file that are the same as the word under the cursor. This PR improves on this default behavior by:

1. Disabling this feature in irrelevant contexts (such as comments and string literals)
2. Disabling this for keywords
3. Taking into account Rocq's lexical analysis

I similarly disabled hover and jump to definition in irrelevant contexts (you were able to jump to definition/hover on things in prose of comments and string literals!).

Nr. 3 means that we now properly see `e` and `e'` as two different tokens. The default vscode behavior led to the very annoying highlight of unrelated identifiers:
<img width="348" height="159" alt="image" src="https://github.com/user-attachments/assets/7e11c33b-3a27-4572-bfe0-048a6a6056a1" />

Now, things are properly distinguished:

<img width="350" height="163" alt="image" src="https://github.com/user-attachments/assets/898b1aad-728d-4530-b5d8-631caf3f1850" />

As future work, it would be better to extend highlight to actual semantic reasoning, not only syntactic.