### PR TITLE
Evaluate DUNE_IN_FILES eagerly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,2 @@
-language-server/_build
-language-server/_opam
-language-server/dm/dune
-language-server/language/dune
-language-server/protocol/dune
-language-server/vsrocqtop/dune
-language-server/tests/dune
-language-server/dm/vsrocq_config.mlh
-language-server/tests/vsrocq_config.mlh
-language-server/*.install
 .DS_Store
 result

--- a/language-server/.gitignore
+++ b/language-server/.gitignore
@@ -1,0 +1,10 @@
+_build/
+_opam/
+dm/dune
+language/dune
+protocol/dune
+vsrocqtop/dune
+tests/dune
+dm/vsrocq_config.mlh
+tests/vsrocq_config.mlh
+*.install

--- a/language-server/Makefile
+++ b/language-server/Makefile
@@ -2,7 +2,7 @@ dune_no_stop = dune $(1)
 dune = dune $(1) --stop-on-first-error
 dune_dev = dune $(1) --stop-on-first-error --profile dev
 dune_fatal = dune $(1) --stop-on-first-error --profile fatalwarnings
-DUNE_IN_FILES = $(shell find . -name "dune.in" | sed -e 's/.in$$//')
+DUNE_IN_FILES := $(shell find . -name "dune.in" | sed -e 's/.in$$//')
 # This makefile is mostly calling dune and dune doesn't like
 # being called in parralel, so we enforce -j1
 .NOTPARALLEL:


### PR DESCRIPTION
Otherwise it is evaluated multiple times per a single call to `make`. This is especially slow when `find` looks through `_build` and `_opam` directories which are large. In my case running `make` would take 15 seconds.

Also I moved some gitignore. Makes it more scoped and the ignores also work in editors if you open only the subfolder.