### PR TITLE
fix: don't delegate proofs that don't guarantee opacity

### DIFF
--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -233,9 +233,9 @@ let interp_qed_delayed ~doc_id ~proof_using ~state_id ~st =
   let control = [] (* FIXME *) in
   let opaque = Vernacexpr.Opaque in
   let pending = CAst.make @@ Vernacexpr.Proved (opaque, None) in
-  (*log fun () -> "calling interp_qed_delayed done";*)
+  log (fun () -> "calling interp_qed_delayed done");
   let interp = Vernacinterp.interp_qed_delayed_proof ~proof ~st ~control pending in
-  (*log fun () -> "interp_qed_delayed done";*)
+  log (fun () -> "interp_qed_delayed done");
   let st = { st with interp } in
   st, success st, assign) 
   |> Result.fold ~ok:(fun x -> x) ~error:(fun x -> CErrors.user_err x)

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -233,9 +233,9 @@ let interp_qed_delayed ~doc_id ~proof_using ~state_id ~st =
   let control = [] (* FIXME *) in
   let opaque = Vernacexpr.Opaque in
   let pending = CAst.make @@ Vernacexpr.Proved (opaque, None) in
-  log (fun () -> "calling interp_qed_delayed done");
+  (* log (fun () -> "calling interp_qed_delayed done"); *)
   let interp = Vernacinterp.interp_qed_delayed_proof ~proof ~st ~control pending in
-  log (fun () -> "interp_qed_delayed done");
+  (* log (fun () -> "interp_qed_delayed done"); *)
   let st = { st with interp } in
   st, success st, assign) 
   |> Result.fold ~ok:(fun x -> x) ~error:(fun x -> CErrors.user_err x)

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -50,7 +50,7 @@ type task =
 type proof_block = {
   proof_sentences : executable_sentence list;
   opener_id : sentence_id;
-  opener_type: Vernacextend.vernac_start option;
+  opener_type: Vernacextend.vernac_start;
 }
 
 type state = {
@@ -103,7 +103,7 @@ let base_id st =
 
 let open_proof_block ex_sentence opener_type st =
   let st = push_ex_sentence ex_sentence st in
-  let block = { proof_sentences = []; opener_id = ex_sentence.id; opener_type = (Some opener_type) } in
+  let block = { proof_sentences = []; opener_id = ex_sentence.id; opener_type } in
   { st with proof_blocks = block :: st.proof_blocks }
 
 let extrude_side_effect ex_sentence st =
@@ -164,10 +164,9 @@ let find_proof_using_annotation { proof_sentences } =
   | ex_sentence :: _ -> find_proof_using ex_sentence.ast
   | _ -> None
 
-(* TODO: clean it up and add tests *)
-let vernac_start_with_no_opacity_guarantee = function
-  | Some (Vernacextend.Doesn'tGuaranteeOpacity, _) -> true
-  | _ -> false
+let proof_opener_guarantees_opacity = function
+  | Vernacextend.GuaranteesOpacity, _ -> true
+  | Vernacextend.Doesn'tGuaranteeOpacity, _ -> false
 
 let is_opaque_flat_proof terminator section_depth block =
   let open Vernacextend in
@@ -175,8 +174,8 @@ let is_opaque_flat_proof terminator section_depth block =
     | VtStartProof _ | VtSideff _ | VtQed _ | VtProofMode _ | VtMeta -> true
     | VtProofStep _ | VtQuery -> false
   in
-  if List.exists has_side_effect block.proof_sentences then None
-  else if vernac_start_with_no_opacity_guarantee block.opener_type then None
+  if List.exists has_side_effect block.proof_sentences
+    || not (proof_opener_guarantees_opacity block.opener_type) then None
   else match terminator with
   | VtDrop -> Some Vernacexpr.SsEmpty
   | VtKeep VtKeepDefined -> None

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -50,6 +50,7 @@ type task =
 type proof_block = {
   proof_sentences : executable_sentence list;
   opener_id : sentence_id;
+  opener_type: Vernacextend.vernac_start option;
 }
 
 type state = {
@@ -100,9 +101,9 @@ let base_id st =
   in
   aux st.proof_blocks
 
-let open_proof_block ex_sentence st =
+let open_proof_block ex_sentence opener_type st =
   let st = push_ex_sentence ex_sentence st in
-  let block = { proof_sentences = []; opener_id = ex_sentence.id } in
+  let block = { proof_sentences = []; opener_id = ex_sentence.id; opener_type = (Some opener_type) } in
   { st with proof_blocks = block :: st.proof_blocks }
 
 let extrude_side_effect ex_sentence st =
@@ -163,7 +164,10 @@ let find_proof_using_annotation { proof_sentences } =
   | ex_sentence :: _ -> find_proof_using ex_sentence.ast
   | _ -> None
 
-
+(* TODO: clean it up and add tests *)
+let vernac_start_with_no_opacity_guarantee = function
+  | Some (Vernacextend.Doesn'tGuaranteeOpacity, _) -> true
+  | _ -> false
 
 let is_opaque_flat_proof terminator section_depth block =
   let open Vernacextend in
@@ -172,6 +176,7 @@ let is_opaque_flat_proof terminator section_depth block =
     | VtProofStep _ | VtQuery -> false
   in
   if List.exists has_side_effect block.proof_sentences then None
+  else if vernac_start_with_no_opacity_guarantee block.opener_type then None
   else match terminator with
   | VtDrop -> Some Vernacexpr.SsEmpty
   | VtKeep VtKeepDefined -> None
@@ -183,8 +188,8 @@ let push_state id ast synterp classif st =
   let open Vernacextend in
   let ex_sentence = { id; ast; classif; synterp; error_recovery = RSkip } in
   match classif with
-  | VtStartProof _ ->
-    base_id st, open_proof_block ex_sentence st, Exec ex_sentence
+  | VtStartProof opener_type ->
+    base_id st, open_proof_block ex_sentence opener_type st, Exec ex_sentence
   | VtQed terminator_type ->
     log (fun () -> "scheduling a qed");
     begin match st.proof_blocks with

--- a/language-server/tests/s_tests.ml
+++ b/language-server/tests/s_tests.ml
@@ -49,6 +49,14 @@ let %test_unit "schedule: transparent lemma" =
   [%test_eq: sentence_id option] (Some s3.id) init;
   [%test_eq: sentence_id] e s4.id;
   ()
+
+let %test_unit "schedule: opener without opacity guarantee" =
+  let st = dm_init_and_parse_test_doc ()~text:"Polymorphic Lemma a : True. Proof. idtac. Qed." in
+  let st, (s1, (s2, (s3, (s4, ())))) = dm_parse st (P(P(P(P O)))) in
+  let init, e = task st s4.id Exec in
+  [%test_eq: sentence_id option] (Some s3.id) init;
+  [%test_eq: sentence_id] e s4.id;
+  ()
  
 let %test_unit "schedule: section with proof using" =
   let st = dm_init_and_parse_test_doc ()~text:"Section A. Variable x : Prop. Lemma a : True. Proof. idtac. Qed." in

--- a/language-server/tests/s_tests.ml
+++ b/language-server/tests/s_tests.ml
@@ -51,13 +51,13 @@ let %test_unit "schedule: transparent lemma" =
   ()
 
 let %test_unit "schedule: opener without opacity guarantee" =
-  let st = dm_init_and_parse_test_doc ()~text:"Polymorphic Lemma a : True. Proof. idtac. Qed." in
-  let st, (s1, (s2, (s3, (s4, ())))) = dm_parse st (P(P(P(P O)))) in
-  let init, e = task st s4.id Exec in
-  [%test_eq: sentence_id option] (Some s3.id) init;
-  [%test_eq: sentence_id] e s4.id;
+  let st = dm_init_and_parse_test_doc ()~text:"From Stdlib Require Import Derive. Derive x in (x = 1) as a. Proof. subst x; reflexivity. Qed." in
+  let st, (s1, (s2, (s3, (s4, (s5, ()))))) = dm_parse st (P(P(P(P(P O))))) in
+  let init, e = task st s5.id Exec in
+  [%test_eq: sentence_id option] (Some s4.id) init;
+  [%test_eq: sentence_id] e s5.id;
   ()
- 
+
 let %test_unit "schedule: section with proof using" =
   let st = dm_init_and_parse_test_doc ()~text:"Section A. Variable x : Prop. Lemma a : True. Proof. idtac. Qed." in
   let st, (s1, (s2, (s3, (s4, (s5, (s6, ())))))) = dm_parse st (P(P(P(P(P(P O)))))) in
@@ -65,7 +65,7 @@ let %test_unit "schedule: section with proof using" =
   [%test_eq: sentence_id option] (Some s5.id) init;
   [%test_eq: sentence_id] q s6.id;
   ()
-  
+
 let %test_unit "schedule: section closed" =
   let st = dm_init_and_parse_test_doc ()~text:"Section A. End A. Lemma a : True. Proof. idtac. Qed." in
   let st, (s1, (s2, (s3, (s4, (s5, (s6, ())))))) = dm_parse st (P(P(P(P(P(P O)))))) in


### PR DESCRIPTION
possibly closes #703

In delegation mode, we look at the VtQed type to determine if the proof has side effects, but some proof "openers" also don't guarantee opacity. We added a check to not delegate the proof if it doesn't guarantee opacity.