### PR TITLE
Do not highlight unicode characters

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -311,6 +311,11 @@
         }
       }
     ],
+    "configurationDefaults": {
+      "[rocq]": {
+          "editor.unicodeHighlight.ambiguousCharacters": false
+      }
+    },
     "commands": [
       {
         "command": "extension.rocq.showManual",


### PR DESCRIPTION
Fixes #905.

Lean does the same thing: https://github.com/leanprover/vscode-lean4/blob/17d1d086d9cce16f885dde102adb056cad15cb50/vscode-lean4/package.json#L1748