### PR TITLE
fix: correctly report feedback from synterp/parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 result
+_opam

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -73,6 +73,7 @@ type sentence_state =
   | Parsed of parsed_ast
 
 type pre_sentence = {
+  id : sentence_id;
   parsing_start : int;
   start : int;
   stop : int;
@@ -268,8 +269,7 @@ let outline doc = compute_outline doc
 let parse_errors parsed =
   List.map snd (LM.bindings parsed.parsing_errors_by_end)
 
-let add_sentence parsed parsing_start start stop (ast: sentence_state) synterp_state scheduler_state_before =
-  let id = Stateid.fresh () in
+let add_sentence parsed id parsing_start start stop (ast: sentence_state) synterp_state scheduler_state_before =
   let scheduler_state_after, schedule = 
     match ast with
     | Error {msg} ->
@@ -705,12 +705,12 @@ let get_entry ast =
 [%%endif]
 
 
-let rec handle_parse_error start parsing_start msg qf ({stream; errors; parsed;} as parse_state) synterp_state =
+let rec handle_parse_error id start parsing_start msg qf ({stream; errors; parsed;} as parse_state) synterp_state =
   log (fun () -> "handling parse error at " ^ string_of_int start);
   let stop = Stream.count stream in
   let str = String.sub (RawDocument.text parse_state.raw) parsing_start (stop - parsing_start) in
   let parsing_error = { msg; start; stop; qf; str} in
-  let sentence = { parsing_start; ast = Error parsing_error; start; stop; synterp_state } in
+  let sentence = { id; parsing_start; ast = Error parsing_error; start; stop; synterp_state } in
   let parsed = sentence :: parsed in
   let errors = parsing_error :: errors in
   let parse_state = {parse_state with errors; parsed} in
@@ -725,6 +725,7 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
     match parse_one_sentence ?loc stream ~st:synterp_state with
     | None, _ (* EOI *) -> false, parse_state
     | Some ast, comments ->
+      let id = Stateid.fresh () in
       let stop = Stream.count stream in
       let begin_line, begin_char, end_char =
               match ast.loc with
@@ -738,11 +739,12 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
       begin
         try
           log (fun () -> "Parsed: " ^ (Pp.string_of_ppcmds @@ Ppvernac.pr_vernac ast));
+          Feedback.set_id_for_feedback parse_state.previous_document.doc_id id;
           let entry = get_entry ast in
           let classification = Vernac_classifier.classify_vernac ast in
           let synterp_state = Vernacstate.Synterp.freeze () in
           let parsed_ast = Parsed { ast = entry; classification; tokens } in
-          let sentence = { parsing_start = start; ast = parsed_ast; start = begin_char; stop; synterp_state } in
+          let sentence = { id; parsing_start = start; ast = parsed_ast; start = begin_char; stop; synterp_state } in
           let parsed = sentence :: parsed in
           let comments = List.map (fun ((start, stop), content) -> {start; stop; content}) comments in
           let parsed_comments = List.append comments parsed_comments in
@@ -753,26 +755,29 @@ and parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments} as pa
           let e, info = Exninfo.capture exn in
           let loc = get_loc_from_info_or_exn e info in
           let qf = Result.value ~default:[] @@ Quickfix.from_exception e in
-          handle_parse_error start begin_char (loc, CErrors.iprint_no_report (e,info)) (Some qf) parse_state synterp_state
+          handle_parse_error id start begin_char (loc, CErrors.iprint_no_report (e,info)) (Some qf) parse_state synterp_state
         end
     | exception (E _ as exn) ->
+      let id = Stateid.fresh () in
       let e, info = Exninfo.capture exn in
       let loc = get_loc_from_info_or_exn e info in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception e in
       junk_sentence_end stream;
-      handle_parse_error start start (loc, CErrors.iprint_no_report (e, info)) (Some qf) {parse_state with stream} synterp_state
+      handle_parse_error id start start (loc, CErrors.iprint_no_report (e, info)) (Some qf) {parse_state with stream} synterp_state
     | exception (CLexer.Error.E _ as exn) -> (* May be more problematic to handle for the diff *)
+      let id = Stateid.fresh () in
       let e, info = Exninfo.capture exn in
       let loc = get_loc_from_info_or_exn e info in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception exn in
       junk_sentence_end stream;
-      handle_parse_error start start (loc,CErrors.iprint_no_report (e, info)) (Some qf) {parse_state with stream} synterp_state
+      handle_parse_error id start start (loc,CErrors.iprint_no_report (e, info)) (Some qf) {parse_state with stream} synterp_state
     | exception exn ->
+      let id = Stateid.fresh () in
       let e, info = Exninfo.capture exn in
       let loc = Loc.get_loc @@ info in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception exn in
       junk_sentence_end stream;
-      handle_parse_error start start (loc, CErrors.iprint_no_report (e,info)) (Some qf) {parse_state with stream} synterp_state
+      handle_parse_error id start start (loc, CErrors.iprint_no_report (e,info)) (Some qf) {parse_state with stream} synterp_state
   end
 and create_parse_event ~doc_id parse_state =
   let priority = Some PriorityManager.parsing in
@@ -802,8 +807,8 @@ let invalidate top_edit top_id parsed_doc new_sentences =
       add_new_or_patch parsed_doc scheduler_state diffs
     | Added new_sentences :: diffs ->
     (* FIXME could have side effect on the following, unchanged sentences *)
-      let add_sentence (parsed_doc,scheduler_state) ({ parsing_start; start; stop; ast; synterp_state } : pre_sentence) =
-        add_sentence parsed_doc parsing_start start stop ast synterp_state scheduler_state
+      let add_sentence (parsed_doc,scheduler_state) ({ id; parsing_start; start; stop; ast; synterp_state } : pre_sentence) =
+        add_sentence parsed_doc id parsing_start start stop ast synterp_state scheduler_state
       in
       let parsed_doc, scheduler_state = List.fold_left add_sentence (parsed_doc,scheduler_state) new_sentences in
       add_new_or_patch parsed_doc scheduler_state diffs

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -40,6 +40,7 @@ type state = {
   document : Document.document;
   document_state: document_state;
   feedback_pipe : feedback_pipe;
+  pending_feedback : feedback_data list;
   checking_state : CheckingManager.state;
 }
 type event =
@@ -350,7 +351,7 @@ let init init_vs ~opts uri ~text =
   let feedback_pipe, feedback_event = init_feedback_pipe ~doc_id in
   let checking_state = CheckingManager.init init_vs ~feedback_pipe in
   let parsebegin_event = Sel.now ~priority:PriorityManager.launch_parsing ParseBegin in
-  let state = { uri; opts; init_vs; document; document_state = Parsing; feedback_pipe; checking_state } in
+  let state = { uri; opts; init_vs; document; document_state = Parsing; feedback_pipe; pending_feedback = []; checking_state } in
   state, [parsebegin_event;feedback_event]
 
 let reset { uri; opts; init_vs; document; checking_state; feedback_pipe } =
@@ -360,7 +361,7 @@ let reset { uri; opts; init_vs; document; checking_state; feedback_pipe } =
   let document = Document.create_document ~doc_id init_vs.synterp text in
   let feedback_pipe, feedback_event = init_feedback_pipe ~doc_id in
   let checking_state = CheckingManager.reset checking_state init_vs ~feedback_pipe in
-  let state = { uri; opts; init_vs; document; checking_state; document_state = Parsing; feedback_pipe } in
+  let state = { uri; opts; init_vs; document; checking_state; document_state = Parsing; feedback_pipe; pending_feedback = [] } in
   let parsebegin_event = Sel.now ~priority:PriorityManager.launch_parsing ParseBegin in
   state, [parsebegin_event;feedback_event]
 
@@ -376,7 +377,7 @@ let apply_text_edits state edits =
     let offset = String.length new_text - edit_length in
     let document = Document.shift_feedbacks_and_checking_errors ~start ~offset document in
     let checking_state = CheckingManager.shift_overview state.checking_state ~before:state.document ~after:document ~start:edit_stop ~offset:(String.length new_text - edit_length) in
-    {state with checking_state; document}
+    {state with checking_state; document; document_state = Parsing; pending_feedback = []}
   in
   let state = List.fold_left apply_edit_and_shift_diagnostics_locs_and_overview state edits in
   let priority = Some PriorityManager.launch_parsing in
@@ -386,14 +387,19 @@ let apply_text_edits state edits =
 let handle_feedback_event state (_, id, msg) =
   { state with document = Document.append_feedback state.document id msg }
 
+let handle_feedback_events state feedback =
+  match state.document_state with
+  | Parsing -> { state with pending_feedback = state.pending_feedback @ feedback }
+  | Parsed -> List.fold_left handle_feedback_event state feedback
+
 let handle_event ev st =
   match ev with
   | LocalFeedback l ->
-     let state = List.fold_left handle_feedback_event st l in
+     let state = handle_feedback_events st l in
      make_handled_event ~state ~update_view:true ~events:[local_feedback state.feedback_pipe.sel_feedback_queue] ()
   | ParseBegin ->
     let document, events = Document.validate_document st.document in
-    let state = {st with document} in
+    let state = {st with document; document_state = Parsing} in
     let events = inject_doc_events events in
     make_handled_event ~state ~update_view:true ~events ()
   | DocumentEvent ev ->
@@ -406,7 +412,8 @@ let handle_event ev st =
     | Some parsing_end_info ->
       let st = validate_document st parsing_end_info in
       let checking_state, events = CheckingManager.validate_document st.document st.checking_state in
-      make_handled_event ~state:{st with checking_state} ~events:(inject_im_events events) ~update_view:true ()
+      let state = handle_feedback_events { st with checking_state; pending_feedback = [] } st.pending_feedback in
+      make_handled_event ~state ~events:(inject_im_events events) ~update_view:true ()
     end
   | InteractionManagerEvent ev ->
     let updates, he = CheckingManager.handle_event ~uri:st.uri st.document st.checking_state ev in

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -79,7 +79,7 @@ let%test_unit "parse.error_recovery" =
 let%test_unit "parse.extensions" =
                                               (*          1         2         3         4         5         6         7*)
                                               (*01234567890123456789012345678901234567890123456789012345678901234567890*)
-  let st, init_events = em_init_test_doc ~text:"Notation \"## x\" := x (at level 0). Definition f (x : nat) := ##xx." in
+  let st, init_events = em_init_test_doc ~text:"Notation \"## x\" := x (at level 1). Definition f (x : nat) := ##xx." in
   let sentences = Document.sentences @@ DocumentManager.Internal.document st in
   let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   [%test_eq: int list] start_positions [ 0; 35 ];
@@ -219,10 +219,10 @@ let%test_unit "exec.insert" =
   *)
 
 let%test_unit "parse.feedback_attached_before_execution" =
-  let st, _init_events = em_init_test_doc ~text:"Require Coq.Vectors.Vector." in
+  let st, _init_events = em_init_test_doc ~text:"Notation \"## x\" := x (at level 0)." in
   let st, (s1, ()) = dm_parse st (P O) in
   check_diag st [
-    D (s1.id,Warning,".*deprecated-from-Coq.*")
+    D (s1.id,Warning,".*level-0-notation-not-closed*")
   ]
 
 let%test_unit "edit.shift_warning_in_sentence" =

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -218,6 +218,13 @@ let%test_unit "exec.insert" =
   [%test_eq: int list] positions [ 0; 22 ]
   *)
 
+let%test_unit "parse.feedback_attached_before_execution" =
+  let st, _init_events = em_init_test_doc ~text:"Require Coq.Vectors.Vector." in
+  let st, (s1, ()) = dm_parse st (P O) in
+  check_diag st [
+    D (s1.id,Warning,".*deprecated-from-Coq.*")
+  ]
+
 let%test_unit "edit.shift_warning_in_sentence" =
   let st, init_events = em_init_test_doc ~text:"#[deprecated(note = \"foo\", since = \"foo\")] Definition x := true. Definition y := x." in
   let st, (s1, (s2, ())) = dm_parse st (P(P O)) in


### PR DESCRIPTION
- Add ids to pre_sentences, so we can set their ids as feedback defaults sooner
- Manually collect feedback while parsing is in progress, so that we don't try reporting diagnostics to yet unregistered sentences