### PR TITLE
Fix conflicting yojson and ppx_yojson_conv_lib dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,27 +20,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1760596604,
-        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -60,17 +60,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1774356043,
-        "narHash": "sha256-trmMEiUNdrkgUGcbWR+eTUkjTFgZM6yswVnJfLv3ri8=",
+        "lastModified": 1780340252,
+        "narHash": "sha256-zNCs2aVl1djpd0SfydniLw8GiR5IBiSsuJSnoelmHT4=",
         "owner": "rocq-prover",
         "repo": "rocq",
-        "rev": "f5272dea10768c74e5a83a17ea594a48057359c4",
+        "rev": "eebacb3bb172082ca7403525483510ab85212a08",
         "type": "github"
       },
       "original": {
         "owner": "rocq-prover",
         "repo": "rocq",
-        "rev": "f5272dea10768c74e5a83a17ea594a48057359c4",
+        "rev": "eebacb3bb172082ca7403525483510ab85212a08",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    rocq-master = { url = "github:rocq-prover/rocq/5358976838128ff6125ee64e3b3d08dac45fc2f3"; }; # Should be kept in sync with PIN_COQ in CI workflow
+    rocq-master = { url = "github:rocq-prover/rocq/eebacb3bb172082ca7403525483510ab85212a08"; }; # Should be kept in sync with PIN_COQ in CI workflow
     rocq-master.inputs.nixpkgs.follows = "nixpkgs";
     rocq-master.inputs.flake-utils.follows = "flake-utils";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
                 ++ (with coq.ocamlPackages; [
                   ocaml
                   findlib
-                  yojson
+                  yojson_2
                   ppx_inline_test
                   ppx_assert
                   ppx_sexp_conv
@@ -60,7 +60,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits
@@ -94,7 +98,7 @@
                 ]
                 ++ (with coq.ocamlPackages; [
                   ocaml
-                  yojson
+                  yojson_2
                   findlib
                   ppx_inline_test
                   ppx_assert
@@ -103,7 +107,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits
@@ -137,7 +145,7 @@
                 ]
                 ++ (with coq.ocamlPackages; [
                   ocaml
-                  yojson
+                  yojson_2
                   findlib
                   ppx_inline_test
                   ppx_assert
@@ -146,7 +154,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits
@@ -180,7 +192,7 @@
                 ]
                 ++ (with coq.ocamlPackages; [
                   ocaml
-                  yojson
+                  yojson_2
                   findlib
                   ppx_inline_test
                   ppx_assert
@@ -189,7 +201,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits
@@ -223,7 +239,7 @@
                 ]
                 ++ (with coq.ocamlPackages; [
                   ocaml
-                  yojson
+                  yojson_2
                   findlib
                   ppx_inline_test
                   ppx_assert
@@ -232,7 +248,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits
@@ -248,7 +268,7 @@
 
         vsrocq-language-server-coq-master =
           # Notice the reference to nixpkgs here.
-          with import nixpkgs {inherit system;}; let
+          with import nixpkgs-unstable {inherit system;}; let
             ocamlPackages = ocaml-ng.ocamlPackages_4_14;
           in
             ocamlPackages.buildDunePackage {
@@ -266,7 +286,7 @@
                 ]
                 ++ (with coq.ocamlPackages; [
                   ocaml
-                  yojson
+                  yojson_2
                   findlib
                   ppx_inline_test
                   ppx_assert
@@ -275,7 +295,11 @@
                   ppx_optcomp
                   ppx_import
                   sexplib
-                  ppx_yojson_conv
+                  (ppx_yojson_conv.override {
+                    ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+                      yojson = yojson_2;
+                    };
+                  })
                   lsp
                   sel
                   memprof-limits


### PR DESCRIPTION
@gares as I wrote on Zulip this resolves the duplicate dependencies, but then fails to build on master anyways, because it can't find rocq-runtime or something. But I think that needs someone more familiar with dune/ocaml than me to take a look.