### PR TITLE
Pretty print json only for logging

### DIFF
--- a/language-server/vsrocqtop/lspManager.ml
+++ b/language-server/vsrocqtop/lspManager.ml
@@ -82,10 +82,10 @@ let lsp : event Sel.Event.t =
 
 
 let output_json obj =
-  let msg  = Yojson.Safe.pretty_to_string ~std:true obj in
+  let msg  = Yojson.Safe.to_string ~std:true obj in
   let size = String.length msg in
   let s = Printf.sprintf "Content-Length: %d\r\n\r\n%s" size msg in
-  log (fun () -> "sent: " ^ msg);
+  log (fun () -> "sent: " ^ Yojson.Safe.pretty_to_string ~std:true obj);
   ignore(Unix.write_substring Unix.stdout s 0 (String.length s)) (* TODO ERROR *)
 
 let output_notification notif =
@@ -611,8 +611,7 @@ let handle_lsp_event = function
     lsp :: (* the event is recurrent *)
     begin try
       let json = Jsonrpc.Packet.yojson_of_t rpc in
-      let msg = Yojson.Safe.pretty_to_string ~std:true json in
-      log (fun () -> "received: " ^ msg);
+      log (fun () -> "received: " ^ Yojson.Safe.pretty_to_string ~std:true json);
       begin match rpc with
       | Request req ->
           log (fun () -> "ui request: " ^ req.method_);


### PR DESCRIPTION
A synthetic tactic like

```rocq
do 13 destruct (1%nat).
```

Causes the creation of around 8000 goals. This results in a goalView notification to have a size of 27MB and it takes around 0.8s to encode in JSON on my computer.

Not doing pretty printing reduces the size down to 11MB and it takes 0.1s to encode. It surely also speeds up decoding, but I don't have a good way to measure that.