### PR TITLE
test: wait on published diagnostics instead of sleeping for 10 seconds

### DIFF
--- a/client/src/test/suite/common.ts
+++ b/client/src/test/suite/common.ts
@@ -14,6 +14,94 @@ export async function openTextFile(file: string): Promise<vscode.Uri> {
     return docUri;
 }
 
-export async function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Waits until the diagnostics published for `uri` satisfy `predicate`, and
+ * returns them. Rejects after `timeoutMs` instead of continuing with whatever
+ * happens to be there.
+ *
+ * The wait condition and the assertion must be two different statements. The
+ * wait is only a synchronisation point — "the server has said something about
+ * this document" — and the assertion is what the test is actually about
+ * (count, severity, message). A predicate that repeats the assertion makes the
+ * test vacuous: it can only be reached by already being true.
+ *
+ * Known limitation: this cannot establish the *absence* of diagnostics. An
+ * empty array is also the state before the server has published anything, so
+ * `(d) => d.length === 0` holds from the first instant and asserts nothing.
+ * Distinguishing "checked, no errors" from "not checked yet" needs the
+ * progress ranges carried by `prover/updateHighlights`, which the extension
+ * consumes for its decorations and does not expose through the `vscode` API.
+ */
+export function waitForDiagnostics(
+    uri: vscode.Uri,
+    predicate: (diagnostics: readonly vscode.Diagnostic[]) => boolean,
+    timeoutMs = 10000,
+): Promise<readonly vscode.Diagnostic[]> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(
+                new Error(
+                    `Timed out after ${timeoutMs}ms waiting on diagnostics for ` +
+                        `${path.basename(uri.fsPath)}; last seen: ` +
+                        `${JSON.stringify(vscode.languages.getDiagnostics(uri))}`,
+                ),
+            );
+        }, timeoutMs);
+
+        const check = () => {
+            const diagnostics = vscode.languages.getDiagnostics(uri);
+            if (!predicate(diagnostics)) {
+                return;
+            }
+            clearTimeout(timer);
+            subscription.dispose();
+            resolve(diagnostics);
+        };
+
+        const subscription = vscode.languages.onDidChangeDiagnostics((e) => {
+            if (
+                e.uris.some((changed) => changed.toString() === uri.toString())
+            ) {
+                check();
+            }
+        });
+
+        // The document may already be checked by the time we subscribe.
+        check();
+    });
+}
+
+/**
+ * At least one diagnostic has been published.
+ *
+ * Only sound as a wait condition for a fixture whose diagnostics can all come
+ * from the same sentence. The server publishes the diagnostics of the whole
+ * document after every executed sentence, so for a fixture that fails in more
+ * than one place this predicate is satisfied by a mid-check reading and the
+ * test goes on to assert against a partial document. Use `diagnosticOnLine`
+ * there instead.
+ */
+export function anyDiagnostic(
+    diagnostics: readonly vscode.Diagnostic[],
+): boolean {
+    return diagnostics.length > 0;
+}
+
+/**
+ * At least one diagnostic starts on `line` (zero-based).
+ *
+ * Point this at the last sentence of the fixture to get a terminal condition:
+ * a diagnostic reported there means checking has reached the end of the
+ * document, so the reading that follows is the final one rather than one of
+ * the intermediate publications.
+ *
+ * This stays a synchronisation point and not the assertion: it fixes *where*
+ * the server must have spoken, while the test still asserts *what* it said.
+ */
+export function diagnosticOnLine(
+    line: number,
+): (diagnostics: readonly vscode.Diagnostic[]) => boolean {
+    return (diagnostics) =>
+        diagnostics.some((d) => d.range.start.line === line);
 }

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -14,9 +14,10 @@ suite("Should get diagnostics", function () {
 
         const doc = await common.openTextFile("basic.v");
 
-        await common.sleep(10000); // Wait for server initialization
-
-        const diagnostics = vscode.languages.getDiagnostics(doc);
+        const diagnostics = await common.waitForDiagnostics(
+            doc,
+            common.anyDiagnostic,
+        );
 
         expect(diagnostics.length).toBe(1);
 
@@ -35,10 +36,10 @@ suite("Should get diagnostics", function () {
         const doc1 = await common.openTextFile("basic.v");
         const doc2 = await common.openTextFile("warn.v");
 
-        await common.sleep(10000); // Wait for server initialization
-
-        const diagnostics1 = vscode.languages.getDiagnostics(doc1);
-        const diagnostics2 = vscode.languages.getDiagnostics(doc2);
+        const [diagnostics1, diagnostics2] = await Promise.all([
+            common.waitForDiagnostics(doc1, common.anyDiagnostic),
+            common.waitForDiagnostics(doc2, common.anyDiagnostic),
+        ]);
 
         expect(diagnostics1.length).toBe(1);
         expect(diagnostics2.length).toBe(1);

--- a/client/src/test/suite/feedback.test.ts
+++ b/client/src/test/suite/feedback.test.ts
@@ -16,10 +16,10 @@ suite("Should get diagnostics in the appropriate tab", function () {
         const doc1 = await common.openTextFile("basic.v");
         const doc2 = await common.openTextFile("warn.v");
 
-        await common.sleep(10000); // Wait for server initialization
-
-        const diagnostics1 = vscode.languages.getDiagnostics(doc1);
-        const diagnostics2 = vscode.languages.getDiagnostics(doc2);
+        const [diagnostics1, diagnostics2] = await Promise.all([
+            common.waitForDiagnostics(doc1, common.anyDiagnostic),
+            common.waitForDiagnostics(doc2, common.anyDiagnostic),
+        ]);
 
         expect(diagnostics1.length).toBe(1);
         expect(diagnostics1[0].message).toMatch(

--- a/client/src/test/suite/feedback_delegation.test.ts
+++ b/client/src/test/suite/feedback_delegation.test.ts
@@ -4,6 +4,9 @@ import { expect } from "expect";
 import * as vscode from "vscode";
 import * as common from "./common";
 
+/** Zero-based line of `Qed.`, the last sentence of delegate_proof.v. */
+const QED_LINE = 5;
+
 suite("Should get diagnostics in the appropriate tab", function () {
     this.timeout(20000);
 
@@ -11,18 +14,24 @@ suite("Should get diagnostics in the appropriate tab", function () {
         const ext = vscode.extensions.getExtension("rocq-prover.vsrocq")!;
         await ext.activate();
 
-        vscode.workspace
+        // Awaited: an unawaited update leaves the server free to check the
+        // document under the previous delegation mode.
+        await vscode.workspace
             .getConfiguration()
             .update("vsrocq.proof.delegation", "Delegate");
-        vscode.workspace.getConfiguration().update("vsrocq.proof.mode", 1);
+        await vscode.workspace
+            .getConfiguration()
+            .update("vsrocq.proof.mode", 1);
 
         const doc1 = await common.openTextFile("delegate_proof.v");
         const doc2 = await common.openTextFile("warn.v");
 
-        await common.sleep(10000); // Wait for server initialization
-
-        const diagnostics1 = vscode.languages.getDiagnostics(doc1);
-        const diagnostics2 = vscode.languages.getDiagnostics(doc2);
+        const [diagnostics1, diagnostics2] = await Promise.all([
+            // delegate_proof.v fails twice under a mode that checks the proof
+            // body, so wait on the Qed rather than on the first publication.
+            common.waitForDiagnostics(doc1, common.diagnosticOnLine(QED_LINE)),
+            common.waitForDiagnostics(doc2, common.anyDiagnostic),
+        ]);
 
         // on some setups diagnostics from a leftover tab are somehow here,
         // but on other setups they are not

--- a/client/src/test/suite/feedback_skip.test.ts
+++ b/client/src/test/suite/feedback_skip.test.ts
@@ -4,6 +4,9 @@ import { expect } from "expect";
 import * as vscode from "vscode";
 import * as common from "./common";
 
+/** Zero-based line of `Qed.`, the last sentence of delegate_proof.v. */
+const QED_LINE = 5;
+
 suite("Should get diagnostics in the appropriate tab", function () {
     this.timeout(20000);
 
@@ -11,19 +14,25 @@ suite("Should get diagnostics in the appropriate tab", function () {
         const ext = vscode.extensions.getExtension("rocq-prover.vsrocq")!;
         await ext.activate();
 
-        vscode.workspace
+        // Awaited: an unawaited update leaves the server free to check the
+        // document under the previous delegation mode.
+        await vscode.workspace
             .getConfiguration()
             .update("vsrocq.proof.delegation", "Skip");
-        vscode.workspace.getConfiguration().update("vsrocq.proof.mode", 1);
+        await vscode.workspace
+            .getConfiguration()
+            .update("vsrocq.proof.mode", 1);
 
         const doc1 = await common.openTextFile("delegate_proof.v");
 
         const doc2 = await common.openTextFile("warn.v");
 
-        await common.sleep(10000); // Wait for server initialization
-
-        const diagnostics1 = vscode.languages.getDiagnostics(doc1);
-        const diagnostics2 = vscode.languages.getDiagnostics(doc2);
+        const [diagnostics1, diagnostics2] = await Promise.all([
+            // delegate_proof.v fails twice under a mode that checks the proof
+            // body, so wait on the Qed rather than on the first publication.
+            common.waitForDiagnostics(doc1, common.diagnosticOnLine(QED_LINE)),
+            common.waitForDiagnostics(doc2, common.anyDiagnostic),
+        ]);
 
         // on some setups diagnostics from a leftover tab are somehow here,
         // but on other setups they are not


### PR DESCRIPTION
Every test in the client suite waited with a fixed `sleep(10000)` and then read whatever diagnostics happened to be there. This PR changes it to subscribe to diagnostic changes instead.
Specifically, `common.waitForDiagnostics` subscribes to `vscode.languages.onDidChangeDiagnostics`, re-evaluates a test-supplied predicate on every change for the document, and rejects on timeout instead of proceeding with a stale reading.

The wait condition and the assertion must be different predicates. The wait condition is only there to decide when to stop waiting (might not only be time but some specific behavior depending on the fixture), while the assertion is the actual claim we are testing for. If the wait condition is the same as the assertion, then the assertion is redundant.

Waiting on the first publication is not enough for every fixture. `update_view` runs once per executed sentence and publishes the diagnostics of the whole document each time, so a fixture that fails in more than one place is observable in a partial state. `delegate_proof.v` is one: it fails at `apply foobar.` and again at `Qed.`, and a test that resumes on the first of those reads the wrong error. `common.diagnosticOnLine` gives the two tests over that fixture a terminal condition instead, such that a diagnostic on the last sentence means checking reached the end of the document. It still fixes only *where* the server must have spoken, leaving *what* it said to the assertion.

The configuration updates are now awaited. `getConfiguration().update` returns before the setting has reached the server, so an unawaited call leaves the document free to be checked under the previous delegation mode (or under the declared default, `None`, which checks the proof body that `Skip` is meant to drop).

This harness cannot establish the *absence* of diagnostics, which is documented in the helper rather than worked around. An empty array is also the state before the server has published anything, so `d.length === 0` holds from the first instant. Telling "checked, no errors" apart from "not checked yet" needs the progress ranges of `prover/updateHighlights`, which the extension consumes for its decorations and does not expose to the `vscode` API.

Measured on macOS arm64, VS Code 1.134.0. The suite goes from 50s to 0.7s, with 5 tests passing.
Measured on Linux x86_64 (Arch, i5-12600KF), VS Code 1.134.0, Rocq 9.2: The suite goes from 51s to 1.5 s, with 5 tests passing.
