### PR TITLE
ci: stop the dry-run publish from running unconditionally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,8 +248,7 @@ jobs:
     # Dry run: it packages the extension and checks that both marketplace
     # actions accept the result, with a stub token. It depends on
     # build-extension so that it cannot report success while packaging is
-    # broken; `if: success()` on a job with no `needs` is vacuously true and
-    # gated nothing.
+    # broken.
     needs: build-extension
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,13 @@ jobs:
           generate_release_notes: true
 
   publish-extension:
+    # Dry run: it packages the extension and checks that both marketplace
+    # actions accept the result, with a stub token. It depends on
+    # build-extension so that it cannot report success while packaging is
+    # broken; `if: success()` on a job with no `needs` is vacuously true and
+    # gated nothing.
+    needs: build-extension
     runs-on: ubuntu-latest
-    if: success()
     steps:
     - name: Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
Removed `if:success()` and added `needs` to `publish-extension` because `success()` on a job with no dependencies is vacuously true (https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#success), so the job started immediately alongside the build matrix and reported success regardless of whether the extension built at all. 