### PR TITLE
ci: keep a failed run's diagnostics readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,9 @@ jobs:
         command: |
             nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd client && npm test"
       if: runner.os != 'Linux'
-    - if: ${{ failure() }}
-      run: cat /tmp/vsrocq_init_log.*
+    - name: Language server init log
+      if: ${{ failure() }}
+      run: cat /tmp/vsrocq_init_log.* 2>/dev/null || echo "no init log was written"
 
   install-opam:
     strategy:
@@ -135,8 +136,9 @@ jobs:
       env:
         VSROCQPATH: ${{ env.vsrocqtop }}
         VSROCQARGS: "-bt"
-    - if: runner.os == 'Linux' && failure()
-      run: cat /tmp/vsrocq_init_log.*
+    - name: Language server init log
+      if: runner.os == 'Linux' && failure()
+      run: cat /tmp/vsrocq_init_log.* 2>/dev/null || echo "no init log was written"
 
   install-windows:
     if: false
@@ -214,8 +216,9 @@ jobs:
       env:
         VSROCQARGS: "${{ env.vsrocqlib }}"
 
-    - if: ${{ failure() }}
-      run: cat /tmp/vsrocq_init_log.*
+    - name: Language server init log
+      if: ${{ failure() }}
+      run: cat /tmp/vsrocq_init_log.* 2>/dev/null || echo "no init log was written"
 
 
   create-release:


### PR DESCRIPTION
When a job fails, the step that dumps the language server's init log is the first thing anyone opens. Today it is unnamed, so it shows in the log as the raw command, and if no log was written it fails with
```sh
    cat: '/tmp/vsrocq_init_log.*': No such file or directory
```
which adds a second red step to a run that already has one, and says nothing about the failure being investigated.

Naming the step makes it findable in a long job, and falling back to a sentence distinguishes "the server wrote no init log" from "the step itself broke".