### PR TITLE
ci: drop two steps that cannot do anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,21 +48,7 @@ jobs:
     - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - name: Check each yarn.nix up to date
-      if: false
-      run: |
-        cd client && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix"
-        cd goal-view-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix"
-        cd ../search-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix" && cd ..
-        nix fmt new_yarn.nix goal-view-ui/new_yarn.nix search-ui/new_yarn.nix
-        nix fmt yarn.nix goal-view-ui/yarn.nix search-ui/yarn.nix
-        diff new_yarn.nix yarn.nix
-        diff goal-view-ui/new_yarn.nix goal-view-ui/yarn.nix
-        diff search-ui/new_yarn.nix search-ui/yarn.nix
     - run: nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd language-server && make dune-files && dune build --profile ${{ matrix.profile }}"
-      if: ${{matrix.coq != 9}}
-    - run: nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd language-server && make dune-files && dune build --profile ${{ matrix.profile }}"
-      if: ${{matrix.coq == 9}}
     - run: nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd client && npm install && npm run build --workspaces"
     - name: Test xvfb
       uses: Wandalen/wretry.action@v3


### PR DESCRIPTION
The `Check each yarn.nix up to date` step is disabled with `if: false`, and it could not run if it were enabled: `yarn2nix` reads a `yarn.lock`, and there is no `yarn.lock` left in the repository. The client builds with npm and carries a `package-lock.json` instead. Three `yarn.nix` files do survive and flake.nix still points at them, but that is a separate question from a check that has no input to work on.

The build step in nix-dev-build appears twice, gated on `matrix.coq != 9` and `matrix.coq == 9`, running identical commands. Collapsed into one unconditional step.