### PR TITLE
ci: schedule fewer macOS cells on pull requests

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Decide which matrix cells a CI run schedules.
+
+GitHub caps concurrent macOS runners at 5, and the full matrix asks for 16 of
+them (8 Rocq versions x 2 build routes), so those jobs alone cost four waves of
+queueing and set the wall clock for the whole run. A pull request therefore gets
+a reduced set of macOS cells; ubuntu is never reduced, since its cap is 20 and it
+does not queue.
+
+Set FULL=true to get every cell. The workflow does that for anything that is not
+a pull request, and for a pull request carrying the `ci-full` label.
+
+The macOS lists are not symmetric between the two routes. See
+docs/adr/0001-macos-ci-fast-path-is-asymmetric-between-nix-and-opam.md; the short
+version is that the opam packaging of coq-core 8.17.0 through 8.19.1 injects an
+OCAMLPARAM that crashes the OCaml 4.14 compiler on arm64 macOS, so 8.18.0 and
+8.19.0 are kept off the blocking path on that route only. The nix route does not
+go through the opam package and is unaffected.
+
+Run it locally to see what a given event would schedule:
+
+    FULL=false python3 .github/scripts/ci-matrix.py
+"""
+
+import json
+import os
+import sys
+
+OCAML = "4.14.2"
+
+# Devshell suffixes in flake.nix: `nix develop .#vsrocq-<coq>`.
+NIX_ALL = ["8-18", "8-19", "8-20", "9", "9-1", "9-2", "9-3", "master"]
+NIX_MACOS_FAST = ["8-18", "9-2"]
+
+# opam package versions of rocq-core / coq-core.
+OPAM_ALL = ["8.18.0", "8.19.0", "8.20.0", "9.0.0", "9.1.1", "9.2.0", "9.3.dev", "dev"]
+OPAM_MACOS_FAST = ["8.20.0", "9.2.0"]
+
+
+def nix_cells(full):
+    macos = NIX_ALL if full else NIX_MACOS_FAST
+    cells = [{"os": "ubuntu-latest", "coq": c, "profile": "dev"} for c in NIX_ALL]
+    cells.append({"os": "ubuntu-latest", "coq": "master", "profile": "fatalwarnings"})
+    cells += [{"os": "macos-latest", "coq": c, "profile": "dev"} for c in macos]
+    return cells
+
+
+def opam_cells(full):
+    macos = OPAM_ALL if full else OPAM_MACOS_FAST
+    cells = [{"os": "ubuntu-latest", "ocaml-compiler": OCAML, "coq": c} for c in OPAM_ALL]
+    cells += [{"os": "macos-latest", "ocaml-compiler": OCAML, "coq": c} for c in macos]
+    return cells
+
+
+def summary(full, plan):
+    macos = sum(1 for _, _, cells in plan for c in cells if c["os"] == "macos-latest")
+    lines = [
+        "### CI matrix",
+        "",
+        "Full matrix: `%s`" % ("yes" if full else "no, pull request fast path"),
+        "",
+        "| Job | cells | of them macOS |",
+        "|---|---|---|",
+    ]
+    for job, _, cells in plan:
+        lines.append(
+            "| `%s` | %d | %d |"
+            % (job, len(cells), sum(1 for c in cells if c["os"] == "macos-latest"))
+        )
+    waves = -(-macos // 5)
+    lines.append("")
+    lines.append(
+        "%d macOS cells, %d %s against a cap of 5 concurrent macOS runners."
+        % (macos, waves, "wave" if waves == 1 else "waves")
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    full = os.environ.get("FULL", "true").lower() == "true"
+
+    # (job in ci.yml, name of the output it reads, its cells)
+    plan = [
+        ("nix-dev-build", "nix", nix_cells(full)),
+        ("install-opam", "opam", opam_cells(full)),
+    ]
+
+    outputs = "".join(
+        "%s=%s\n" % (output, json.dumps({"include": cells}))
+        for _, output, cells in plan
+    )
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as fh:
+            fh.write(outputs)
+    else:
+        sys.stdout.write(outputs)
+
+    text = summary(full, plan)
+    step = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step:
+        with open(step, "a") as fh:
+            fh.write(text)
+    sys.stderr.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,33 @@ on:
     tags:
       - "v*.*.*"
   pull_request:
+    # `labeled` is here so that adding the `ci-full` label starts a run. Without
+    # it the label fires nothing, and "Re-run all jobs" replays the payload the
+    # run started with, which predates the label. Declaring `types` overrides
+    # the defaults, so the other three have to be listed explicitly.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
+  matrix-plan:
+    # Decides which cells this run schedules. GitHub caps concurrent macOS
+    # runners at 5 while the full matrix asks for 16 of them, so a pull request
+    # gets a reduced set of macOS cells and everything else gets all of them.
+    # Label a pull request `ci-full` to get the complete matrix on demand.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      nix: ${{ steps.cells.outputs.nix }}
+      opam: ${{ steps.cells.outputs.opam }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Plan the matrix
+      id: cells
+      env:
+        FULL: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-full') }}
+      run: python3 .github/scripts/ci-matrix.py
+
   build-extension:
     strategy:
       matrix:
@@ -24,16 +48,10 @@ jobs:
         npm run package
 
   nix-dev-build:
+    needs: matrix-plan
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        coq: [8-18, 8-19, 8-20, 9, 9-1, 9-2, 9-3, master]
-        profile: [dev]
-        include:
-          - profile: fatalwarnings
-            coq: master
-            os: ubuntu-latest
+      matrix: ${{ fromJSON(needs.matrix-plan.outputs.nix) }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -84,12 +102,10 @@ jobs:
       run: cat /tmp/vsrocq_init_log.*
 
   install-opam:
+    needs: matrix-plan
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        ocaml-compiler: [4.14.2]
-        coq: [8.18.0, 8.19.0, 8.20.0, 9.0.0, 9.1.1, 9.2.0, 9.3.dev, dev]
+      matrix: ${{ fromJSON(needs.matrix-plan.outputs.opam) }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/docs/adr/0001-macos-ci-fast-path-is-asymmetric-between-nix-and-opam.md
+++ b/docs/adr/0001-macos-ci-fast-path-is-asymmetric-between-nix-and-opam.md
@@ -1,0 +1,95 @@
+# ADR-0001: The macOS CI fast path is deliberately asymmetric between the nix and opam routes
+
+**Status:** TBD
+**Date:** 2026-08-24
+
+## Context
+
+Most of a CI run is macOS jobs waiting for a free runner.
+For instance, [run 32170095477](https://github.com/rocq-prover/vsrocq/actions/runs/32170095477) for a PR took 26 minutes end to end, and what ended it was `nix-dev-build (macos-latest, 9-1, dev)`, which spent 19.9 of those minutes queued and 6.2 running.
+Its 17 macOS jobs averaged 9.5 minutes queued against 6.2 running, while the 20 ubuntu jobs of the same run averaged 0.5 minutes queued, 3.1 at worst.
+Similarly, [run 32649544820](https://github.com/rocq-prover/vsrocq/actions/runs/32649544820), a push to `main` five days later, has the same shape, 26.7 minutes end to end with 7.7 minutes queued against 5.1 running on macOS and 0.2 queued on ubuntu.
+
+`ci.yml` schedules 16 macOS cells per run, 8 Rocq versions × 2 independent build routes (`nix-dev-build` and `install-opam`), and GitHub caps concurrent macOS jobs at 5 on the Free, Pro and Team plans ([job concurrency limits](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)), so those 16 cells execute in 4 waves of about 6 minutes.
+The ubuntu cap is 20 and is never reached.
+
+The two routes do not cover the same ground:
+
+- **nix** builds Rocq from nixpkgs and is the only place where tests actually execute on Darwin (the Electron suite and the LSP suite over stdio).
+- **opam** builds `rocq-core` from source with the system toolchain.
+  On macOS it runs no tests at all, since every test step in `install-opam` is gated on `runner.os == 'Linux'`.
+  Its entire value on Darwin is as a build check of the opam packaging route.
+
+The opam route fails intermittently on older macOS cells.
+What is observed is that the `install-opam` macOS cell for `coq-core` 8.19.0 fails part of the time, with the OCaml compiler aborting during the build, and that the same cell passes on a rerun.
+The nix route has never shown it.
+
+The suspected cause is the `build-env` the `coq-core` opam package sets, `OCAMLPARAM = "_,w=-46,warn-error=-a,keywords=5.2"`.
+Compiler-libs binaries parse `OCAMLPARAM` at startup, and `keywords=5.2` means nothing to a compiler older than 5.2, which appears to reach an `assert false` in `utils/warnings.ml`.
+That would make the affected range `coq-core` 8.17.0 through 8.19.1, with 8.19.2 and later unaffected because the variable is added in opam packaging rather than being present in the Rocq source tarball, and it would explain why 8.18.0 sits inside the range yet is not seen failing, the fault being sensitive to the exact argv, environment and paths of each build.
+
+The mechanism has not been confirmed end to end, and only the 8.19.0 cell has been seen failing.
+The decision below rests on the observation that those cells are unreliable on Darwin, and holds whatever the explanation turns out to be.
+If opam's `build-env` is the cause there is no CI-side workaround, since it overrides the ambient value.
+
+## Decision
+
+On `pull_request`, macOS runs 4 cells instead of 16, one wave instead of four:
+
+| Route | Versions on the PR fast path |
+|---|---|
+| nix | `8-18`, `9-2` |
+| opam | `8.20.0`, `9.2.0` |
+
+ubuntu keeps the full 8-version sweep on both routes, where it costs nothing in wall clock.
+The complete 16-cell macOS matrix runs on push to the default branch, and on demand on a PR via the `ci-full` label.
+
+The version lists differ between the two routes **on purpose**:
+
+- The oldest-supported end is represented by `nix 8-18`, not by `opam 8.18.0`, because only the opam route shows the intermittent failure.
+  Putting `8.18.0` on the fast path would place a cell from the suspect range on the blocking path of every PR, and with only two opam-macOS cells that is half the signal.
+  A red run there is not attributable to the PR that triggered it.
+- `opam 8.20.0` is the oldest 8.x outside the suspect range, so the fast path still checks an 8.x opam build on Darwin.
+- `9.2.0` and `9-2` are on both routes because that is the current stable release, the one most users build against.
+- The macOS `master`, `9-3`, `dev` and `9.3.dev` cells are off the fast path.
+  When they break, they break because upstream moved rather than because of the PR under review.
+  They keep running on ubuntu, where they cost no wall clock, so the signal is delayed on Darwin only.
+
+`8.18.0` and `8.19.0` on the opam route are not dropped, but move to the full sweep, where a failure informs instead of blocking.
+
+The cells are emitted as JSON by `.github/scripts/ci-matrix.py`, run in a `matrix-plan` job, and consumed as `matrix: ${{ fromJSON(...) }}`.
+A cross product `os × coq` cannot express different version lists per OS, and duplicating the step lists per OS would double an already-drifting set of steps.
+Running the script with `FULL=true` reproduces today's matrix cell for cell, which is what makes the reduced set the only thing this change alters.
+
+The `ci-full` label requires `on: pull_request: types: [opened, synchronize, reopened, labeled]`.
+Declaring `types` overrides the defaults, so all four must be listed.
+Without `labeled`, applying the label fires no run at all, and "Re-run all jobs" replays the original payload, which does not carry the label.
+
+## Alternatives considered
+
+**Keep `opam 8.18.0` and mitigate the flake** (retry the step, or `continue-on-error` on that cell).
+Rejected, because `continue-on-error` reports the cell green whether or not it built, which removes the only signal that route provides on Darwin, and a retry does not fix a layout-sensitive fault, since perturbing the build moves the failure rather than removing it.
+
+**Drop the opam route from macOS entirely** and rely on nix there.
+Rejected, because nix cannot see opam-packaging failures on Darwin at all, and the intermittent failure above is exactly the class of bug that only this route reports.
+
+**Trim by version for all events rather than adding a fast path.**
+Rejected, because it would also reduce coverage on the default branch and on releases, which is where the full sweep is worth its cost.
+
+**A nightly `cron` for the full sweep.**
+A reasonable alternative, and compatible with this change rather than a replacement for it.
+It would also bound how long a break in the `master` and `dev` cells goes unnoticed, which is the delay this decision accepts on Darwin.
+`schedule` only fires from the workflow file on the default branch, so it cannot be exercised from a pull request branch, whereas the `ci-full` label can.
+
+## Consequences
+
+- A PR that breaks the opam build on macOS specifically for Rocq 8.18.0 or 8.19.0 is not caught until the full sweep runs.
+  Given that the only known failure mode in that range is upstream packaging rather than this codebase, this is an accepted loss.
+- The asymmetry between the two version lists looks like an oversight.
+  Anyone "restoring symmetry" by adding `8.18.0` back to the opam fast path reintroduces the blocking flake, and this ADR is the reason it is not there.
+- If the `install-opam` matrix is ever bumped from `8.19.0` to `8.19.2`, which would be the cheapest remedy if the hypothesis above is right, the argument for excluding `8.18.0` still holds, since no 8.18.x is outside the suspect range.
+- ubuntu still runs the `master` and `dev` cells on every pull request, so a merge can still be blocked by upstream having moved.
+  Cutting those from the fast path as well is a separate decision, not taken here, since on ubuntu they cost no wall clock and they are the earliest warning that upstream broke us.
+- The label path is code that nothing exercises unless someone uses it.
+  It has to be verified deliberately, by applying `ci-full` to a PR once and confirming the 16 macOS cells come back.
+  Otherwise it will be discovered broken at the moment it is first needed.


### PR DESCRIPTION
This is a proposal to cut the macOS matrix on pull requests from 16 cells to 4, one queueing wave instead of four, because GitHub caps concurrent macOS runners at 5 and those cells set the duration of the whole run. Locally tested it went from 26-30 minutes down to 10-12 minutes for the complete workflow (to check how it goes here).

Ubuntu is left untouched so that it runs every combination (Github limits concurrent runners to 20, and we don't reach the limit), and every other event plus any pull request labelled `ci-full` still gets the complete matrix. This requires adding the `ci-label` to the repo if we want to trigger it.

The two routes get different version lists because the older opam macOS cells fail intermittently on arm64 (e.g. the 8.19.0 runs), so opam starts at 8.20.0 while nix keeps the remaining versions that were left out (8.18 and 8.19).
ADR-0001 records the reasoning and the suspected cause, so that restoring the symmetry does not quietly reintroduce the flake. 

The cells are generated by `.github/scripts/ci-matrix.py` because a cross product `os x coq` cannot express per-OS version lists, and running it with `FULL=true` reproduces today's matrix cell for cell. The trigger gains the labeled type, without which applying the label fires no run at all.