### PR TITLE
ci: bump setup-node to v7 and let it cache the npm store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: 22.x
+        cache: npm
+        cache-dependency-path: client/package-lock.json
     - run: |
         cd client
         npm run package
@@ -122,10 +124,12 @@ jobs:
         echo "vsrocqtop=`which vsrocqtop`" >> $GITHUB_ENV
         vsrocqtop -v
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v7
       if: runner.os == 'Linux'
       with:
         node-version: 22
+        cache: npm
+        cache-dependency-path: client/package-lock.json
 
     - run: cd client && npm run package
       if: runner.os == 'Linux'
@@ -157,9 +161,11 @@ jobs:
 
     - run: C:\ci\cygwin64\bin\bash.exe --login -c 'echo vsrocqtop=$(cygpath -m $(which vsrocqtop))' >> $Env:GITHUB_ENV
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v7
       with:
         node-version: 22
+        cache: npm
+        cache-dependency-path: client/package-lock.json
 
     - run: cd client && npm run package && npm test
       env:
@@ -201,9 +207,11 @@ jobs:
         eval $(opam env)
         cd language-server && make test
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v7
       with:
         node-version: 22
+        cache: npm
+        cache-dependency-path: client/package-lock.json
 
     - run: |
         eval $(opam env)
@@ -251,9 +259,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: 22.x
+        cache: npm
+        cache-dependency-path: client/package-lock.json
     - name: Pre publish phase
       run: |
         cd client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: client
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -21,9 +24,7 @@ jobs:
         node-version: 22.x
         cache: npm
         cache-dependency-path: client/package-lock.json
-    - run: |
-        cd client
-        npm run package
+    - run: npm run package
 
   nix-dev-build:
     strategy:

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -20,6 +20,9 @@ jobs:
     publish-extension:
       runs-on: ubuntu-latest
       if: ${{success() && (startsWith(github.ref, 'refs/tags/') || inputs.preRelease)}}
+      defaults:
+        run:
+          working-directory: client
       steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -30,9 +33,7 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
       - name: Pre publish phase
-        run: |
-          cd client
-          npm run package
+        run: npm run package
       - name: Publish to Open VSX Registry
         if: ${{inputs.marketplace == 'openvsx' || inputs.marketplace == 'both'}}
         uses: HaaLeo/publish-vscode-extension@v1.6.2

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
+          cache: npm
+          cache-dependency-path: client/package-lock.json
       - name: Pre publish phase
         run: |
           cd client


### PR DESCRIPTION
Bumped setup-node from v3 to v7 across `ci.yml` and `publish-extension.yml` and turned on `cache: npm`, pointing cache-dependency-path at `client/package-lock.json` since the lockfile is not at the repository root. 

v3 was last released in April 2025, still declares the node16 action runtime the runner now overrides
(https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/), and bundles the form-data advisory CVE-2025-7783 that the v5 line fixed, on a runner holding a GITHUB_TOKEN. 

The cache skips downloading the 557 packages but still unpacks them, so it saves little until an install starts from an empty node_modules.