### PR TITLE
ci: pin every third-party action to a commit SHA

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v3
+      uses: avsm/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c  # v3.7.2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -24,9 +24,9 @@ jobs:
       run: opam install -y -j 2 opam-publish=2.5.0
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+      uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302  # v4.5.0
 
-    - uses: webfactory/ssh-agent@v0.8.0
+    - uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e  # v0.8.0
       with:
           ssh-private-key: ${{ secrets.BOT_SSH_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         (lang dune 3.2)
         (display short)
         EOF
-    - uses: cachix/install-nix-action@v31
+    - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Check each yarn.nix up to date
@@ -65,7 +65,7 @@ jobs:
       if: ${{matrix.coq == 9}}
     - run: nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd client && npm install && npm run build --workspaces"
     - name: Test xvfb
-      uses: Wandalen/wretry.action@v3
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
       with:
         attempt_limit: 5
         attempt_delay: 5000
@@ -73,7 +73,7 @@ jobs:
             xvfb-run nix develop .#vsrocq-${{ matrix.coq }} -c bash -c "cd client && npm test"
       if: runner.os == 'Linux'
     - name: Test
-      uses: Wandalen/wretry.action@v3
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
       with:
         attempt_limit: 5
         attempt_delay: 5000
@@ -96,7 +96,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v3
+      uses: avsm/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c  # v3.7.2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -178,7 +178,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v3
+      uses: avsm/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c  # v3.7.2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -226,7 +226,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302  # v4.5.0
 
       - name: Create language-server archive
         run: |
@@ -235,7 +235,7 @@ jobs:
           git archive -o ../vsrocq-language-server-$VERSION.tar.gz --prefix=vsrocq-language-server-$VERSION/ $GITHUB_SHA .
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: vsrocq-language-server-*.tar.gz
@@ -259,7 +259,7 @@ jobs:
         cd client
         npm run package
     - name: Publish to Open VSX Registry
-      uses: HaaLeo/publish-vscode-extension@v1.6.2
+      uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2  # v1.6.2
       id: publishToOpenVSX
       with:
         pat: 'stub'
@@ -267,7 +267,7 @@ jobs:
         preRelease: false
         dryRun: true
     - name: Publish to Visual Studio Marketplace
-      uses: HaaLeo/publish-vscode-extension@v1.6.2
+      uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2  # v1.6.2
       with:
         pat: 'stub'
         packagePath: ./client/

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -33,7 +33,7 @@ jobs:
           npm run package
       - name: Publish to Open VSX Registry
         if: ${{inputs.marketplace == 'openvsx' || inputs.marketplace == 'both'}}
-        uses: HaaLeo/publish-vscode-extension@v1.6.2
+        uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2  # v1.6.2
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OVSX_PAT }}
@@ -41,7 +41,7 @@ jobs:
           preRelease: ${{ inputs.preRelease }}
       - name: Publish to Visual Studio Marketplace
         if: ${{inputs.marketplace == 'vscode' || inputs.marketplace == 'both'}}
-        uses: HaaLeo/publish-vscode-extension@v1.6.2
+        uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2  # v1.6.2
         with:
           pat: ${{ secrets.VSCE_PAT }}
           packagePath: ./client/

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v3
+      uses: avsm/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c  # v3.7.2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -31,9 +31,9 @@ jobs:
       run: opam install -y -j 2 opam-publish=2.5.0
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+      uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302  # v4.5.0
 
-    - uses: webfactory/ssh-agent@v0.8.0
+    - uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e  # v0.8.0
       with:
           ssh-private-key: ${{ secrets.BOT_SSH_KEY }}
 


### PR DESCRIPTION
Replaced the floating tag on all seventeen third-party uses with the commit SHA it resolves to today, keeping the release in a trailing comment, because a git tag is mutable and `avsm/setup-ocaml@v3` moved on 2026-08-20 in every job of all four workflows with nothing here recording it (https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). 

Each SHA is what its tag points at now, so nothing changes behaviour. `actions/checkout` and `actions/setup-node` stay on tags, being GitHub's own, and nothing moves off a stale major, which matters most for `softprops/action-gh-release` whose v1 tag still points at the v0.1.15 commit from 2022.